### PR TITLE
Chroma wiring to database/ + P0 Mask artifacts

### DIFF
--- a/ROADMAP_NEXT.md
+++ b/ROADMAP_NEXT.md
@@ -1,24 +1,28 @@
 # Next Work Package
 
-Branch: `feature/next-work-validation-chroma`
-
 ## Status
 
-### 1. Canon cleanup + CI retarget — DONE (this PR)
-- [x] Remove `characters/` placeholders
-- [x] Remove `flora_fauna/` placeholders
-- [x] Remove legacy `timeline/` placeholders
-- [x] Add `DESIGN.md` + update `CONTEXT.md` / `database/README.md`
-- [x] Retarget `utils/*` and CI workflows to `database/`
+### 1. Canon cleanup + CI retarget — DONE (PR #21)
 
-### 2. Validation hardening — next
-- [ ] Harden lint (schema checks)
-- [ ] CI hard-fail on lint errors
+### 2. Validation hardening — partial
+- [x] `utils/lint_story.py` validates `database/index.json` + files + cross-refs
+- [x] Story validation CI hard-fails on lint errors
+- [ ] Optional JSON Schema validation against `database/schemas/`
 
-### 3. Chroma wiring — next
-- [ ] Index `database/**/*.json`
-- [ ] Portal smoke-test against real canon
+### 3. Chroma wiring — DONE (this branch)
+- [x] Indexer reads `database/**/*.json`
+- [x] Metadata carries `entity_id`, `entity_type`, `name`/`title`, `epoch`, `culture`
+- [x] Incremental script prefers `database/` paths
+- [ ] Portal smoke-test against live Chroma (manual / local)
 
-### 4. Selective expansion
-- [ ] P0: Mask of Tethys, Mask of Sunlit Stone
-- [ ] P1: Narmada University, Narmada scholars faction
+### 4. Selective expansion — in progress
+- [x] P0: `artifact_mask_of_tethys`
+- [x] P0: `artifact_mask_of_sunlit_stone`
+- [ ] P1: `settlement_narmada_university`
+- [ ] P1: `faction_narmada_scholars`
+- [ ] Event: Vijaya / Mask of Tethys offer
+
+### 5. Still open
+- Event graph: Vijaya arrival node
+- More flora as needed
+- Style debt pass (ruff BLE001/E501) when convenient

--- a/database/artifacts/artifact_mask_of_sunlit_stone.json
+++ b/database/artifacts/artifact_mask_of_sunlit_stone.json
@@ -1,0 +1,13 @@
+{
+  "id": "artifact_mask_of_sunlit_stone",
+  "type": "artifact",
+  "name": "Mask of Sunlit Stone",
+  "material": ["sandstone", "solar inlay"],
+  "power": "steadies will under Asura pressure; amplifies stone-pact oaths",
+  "risk": "rigidity of purpose; refusal to yield even when wise",
+  "related_characters": ["character_kavik", "character_asha", "character_iknaya"],
+  "events": ["event_mask_retrieval"],
+  "notes": "Remaining Mask Family relic used alongside the Mask of Harappa during the Tendua repulsion. Associated with red-sandstone tower rites.",
+  "canon": "primary",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/artifacts/artifact_mask_of_tethys.json
+++ b/database/artifacts/artifact_mask_of_tethys.json
@@ -1,0 +1,13 @@
+{
+  "id": "artifact_mask_of_tethys",
+  "type": "artifact",
+  "name": "Mask of Tethys",
+  "material": ["sea-bronze", "wave motif"],
+  "power": "maritime dominion and allegiance binding",
+  "risk": "vassalage of the bearer’s polity",
+  "related_characters": ["character_vijaya", "character_khadi"],
+  "events": [],
+  "notes": "Offered by Prince Vijaya of Tamralinga during the Tendua/Devourer crisis in exchange for Lothal’s allegiance as a vassal state. Linked to Yaksharaj Kubera traditions.",
+  "canon": "primary",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/index.json
+++ b/database/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SouthOfTethys canonical entity index",
   "counts": {
     "characters": 36,
@@ -8,7 +8,7 @@
     "flora": 6,
     "settlements": 2,
     "regions": 4,
-    "artifacts": 1,
+    "artifacts": 3,
     "factions": 3,
     "mythology": 3
   },
@@ -101,7 +101,11 @@
       "region_gedrosian_desert",
       "region_aravali"
     ],
-    "artifacts": ["artifact_mask_of_harappa"],
+    "artifacts": [
+      "artifact_mask_of_harappa",
+      "artifact_mask_of_tethys",
+      "artifact_mask_of_sunlit_stone"
+    ],
     "factions": [
       "faction_mask_family",
       "faction_kia_clan",

--- a/scripts/index_changes.py
+++ b/scripts/index_changes.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python3
 """Incremental indexer: upsert changed files into Chroma (local or cloud).
 
-Usage patterns:
-  - Upsert specific files:
-      python scripts/index_changes.py --files characters/EliaAkaran.json snippets/inbox/queen_envoy.txt
+Prefer database/ paths. Also accepts snippets/inbox.
 
-  - Upsert files changed in a git range:
-      python scripts/index_changes.py --git-range HEAD~1..HEAD
-
-This script validates metadata (optional) and attempts to upsert vectors into the
-`southoftethys` collection. It will try `collection.upsert(...)` and fall back to
-delete+add if upsert isn't available in the installed chromadb version.
+Examples:
+  python scripts/index_changes.py --files database/characters/character_kavik.json
+  python scripts/index_changes.py --git-range HEAD~1..HEAD
 """
 from __future__ import annotations
 
@@ -19,21 +14,20 @@ import json
 import os
 import subprocess
 from pathlib import Path
+from typing import Any
 
 try:
     import chromadb
     from chromadb.config import Settings
 except Exception:
     raise SystemExit(
-        "chromadb is required. Install services/chroma/requirements.txt or add chromadb to your environment"
+        "chromadb is required. Install services/chroma/requirements.txt"
     )
 
 try:
     from sentence_transformers import SentenceTransformer
 except Exception:
-    raise SystemExit(
-        "sentence-transformers is required (pip install sentence-transformers)"
-    )
+    raise SystemExit("sentence-transformers is required")
 
 _HAVE_VALIDATOR = False
 try:
@@ -42,6 +36,8 @@ try:
     _HAVE_VALIDATOR = True
 except Exception:
     _HAVE_VALIDATOR = False
+
+COLLECTION_NAME = "southoftethys"
 
 
 def git_changed_files(range_spec: str) -> list[Path]:
@@ -54,167 +50,160 @@ def git_changed_files(range_spec: str) -> list[Path]:
 
 def chunk_text(text: str, chunk_size: int = 200) -> list[str]:
     words = text.split()
+    if not words:
+        return [text] if text.strip() else []
     return [
         " ".join(words[i : i + chunk_size]) for i in range(0, len(words), chunk_size)
     ]
 
 
-def build_metadata_for_file(repo_root: Path, fpath: Path, chunk_index: int):
+def entity_document(payload: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key, val in payload.items():
+        if val is None or val == "" or val == []:
+            continue
+        if isinstance(val, (dict, list)):
+            parts.append(f"{key}: {json.dumps(val, ensure_ascii=False)}")
+        else:
+            parts.append(f"{key}: {val}")
+    return "\n".join(parts)
+
+
+def build_metadata(repo_root: Path, fpath: Path, chunk_index: int):
     rel = str(fpath.relative_to(repo_root))
-    meta = {"source": rel, "chunk_index": chunk_index}
-    try:
-        if rel.startswith("timeline/") and fpath.suffix == ".json":
+    meta: dict[str, Any] = {"source": rel, "chunk_index": chunk_index}
+    if fpath.suffix == ".json":
+        try:
             payload = json.loads(fpath.read_text(encoding="utf-8"))
-            meta.update(
-                {
-                    "event_id": payload.get("id", fpath.stem),
-                    "title": payload.get("title"),
-                    "date": payload.get("date"),
-                }
-            )
-        elif rel.startswith("characters/") and fpath.suffix == ".json":
-            payload = json.loads(fpath.read_text(encoding="utf-8"))
-            meta.update(
-                {
-                    "character_id": payload.get("id", fpath.stem),
-                    "name": payload.get("name", payload.get("id", fpath.stem)),
-                }
-            )
-        elif rel.startswith("snippets/"):
-            meta.update({"snippet_id": fpath.stem})
-    except Exception:
-        # best-effort metadata
-        pass
+            if isinstance(payload, dict):
+                meta["entity_id"] = payload.get("id", fpath.stem)
+                meta["entity_type"] = payload.get("type", fpath.parent.name)
+                if payload.get("name"):
+                    meta["name"] = payload["name"]
+                if payload.get("title"):
+                    meta["title"] = payload["title"]
+                if payload.get("epoch"):
+                    meta["epoch"] = payload["epoch"]
+        except Exception:
+            meta["entity_id"] = fpath.stem
+    else:
+        meta["entity_id"] = fpath.stem
     return meta
 
 
 def main():
     p = argparse.ArgumentParser(description="Incremental Chroma index updater")
-    p.add_argument(
-        "--files", nargs="*", help="Paths to files to index (relative to repo)"
-    )
-    p.add_argument(
-        "--git-range",
-        help="Git range to collect changed files (git diff --name-only <range>)",
-    )
-    p.add_argument("--repo-dir", default=".", help="Path to repo root")
+    p.add_argument("--files", nargs="*", help="Paths relative to repo")
+    p.add_argument("--git-range", help="Git range (git diff --name-only)")
+    p.add_argument("--repo-dir", default=".")
     p.add_argument("--chunk-size", type=int, default=200)
-    p.add_argument(
-        "--validate",
-        action="store_true",
-        help="Validate metadata against schemas before upsert (requires jsonschema)",
-    )
+    p.add_argument("--validate", action="store_true")
     p.add_argument(
         "--persist-dir",
         default=os.environ.get("CHROMA_PERSIST_DIR", "storage/chroma"),
-        help="Local persist dir (if not using cloud)",
     )
     args = p.parse_args()
 
     repo_root = Path(args.repo_dir).resolve()
     files: list[Path] = []
     if args.git_range:
-        files += [repo_root / p for p in git_changed_files(args.git_range)]
+        files += [repo_root / x for x in git_changed_files(args.git_range)]
     if args.files:
         files += [repo_root / Path(x) for x in args.files]
 
-    # filter supported file types
-    files = [f for f in files if f.exists() and f.suffix in {".json", ".md", ".txt"}]
+    # Prefer database/ and snippets/
+    files = [
+        f
+        for f in files
+        if f.exists()
+        and f.suffix in {".json", ".md", ".txt"}
+        and (
+            "database" in f.parts
+            or "snippets" in f.parts
+        )
+    ]
     if not files:
-        print("No files to index")
+        print("No database/ or snippets/ files to index")
         return
 
-    # Connect to Chroma (cloud if API key available)
     cloud_key = os.environ.get("CHROMA_CLOUD_API_KEY")
-    collection_name = "southoftethys"
     if cloud_key:
-        tenant = os.environ.get("CHROMA_TENANT")
-        database = os.environ.get("CHROMA_DATABASE")
         client = chromadb.CloudClient(
-            api_key=cloud_key, tenant=tenant, database=database
+            api_key=cloud_key,
+            tenant=os.environ.get("CHROMA_TENANT"),
+            database=os.environ.get("CHROMA_DATABASE"),
         )
         try:
-            collection = client.get_collection(collection_name)
+            collection = client.get_collection(COLLECTION_NAME)
         except Exception:
-            collection = client.create_collection(collection_name)
+            collection = client.create_collection(COLLECTION_NAME)
     else:
         client = chromadb.Client(
             Settings(
-                chroma_db_impl="duckdb+parquet", persist_directory=args.persist_dir
+                chroma_db_impl="duckdb+parquet",
+                persist_directory=args.persist_dir,
             )
         )
         try:
-            collection = client.get_collection(collection_name)
+            collection = client.get_collection(COLLECTION_NAME)
         except Exception:
-            collection = client.create_collection(collection_name)
+            collection = client.create_collection(COLLECTION_NAME)
 
-    embed_model = os.environ.get("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
-    SentenceTransformer(embed_model)
+    SentenceTransformer(os.environ.get("EMBEDDING_MODEL", "all-MiniLM-L6-v2"))
 
     ids, docs, metadatas = [], [], []
     for f in files:
-        text = f.read_text(encoding="utf-8")
-        chunks = chunk_text(text, chunk_size=args.chunk_size)
-        for ci, chunk in enumerate(chunks):
+        raw = f.read_text(encoding="utf-8")
+        if f.suffix == ".json":
+            try:
+                payload = json.loads(raw)
+                text = (
+                    entity_document(payload)
+                    if isinstance(payload, dict)
+                    else raw
+                )
+            except json.JSONDecodeError:
+                text = raw
+        else:
+            text = raw
+
+        for ci, chunk in enumerate(chunk_text(text, args.chunk_size)):
             vid = f"{f.stem}_{ci}"
-            meta = build_metadata_for_file(repo_root, f, ci)
-            payload = {"id": vid, "text": chunk, "metadata": meta}
+            meta = build_metadata(repo_root, f, ci)
             if args.validate:
                 if not _HAVE_VALIDATOR:
-                    raise SystemExit(
-                        "Validation requested but validate_metadata helper not available. Install jsonschema and ensure services.chroma.schemas is importable."
-                    )
+                    raise SystemExit("Validator unavailable")
                 try:
                     validate_metadata(
-                        (
-                            "events"
-                            if str(f).startswith(str(repo_root / "timeline"))
-                            else (
-                                "characters"
-                                if str(f).startswith(str(repo_root / "characters"))
-                                else (
-                                    "snippets"
-                                    if str(f).startswith(str(repo_root / "snippets"))
-                                    else "documents"
-                                )
-                            )
-                        ),
-                        payload,
+                        "documents",
+                        {"id": vid, "text": chunk, "metadata": meta},
                     )
                 except Exception as e:
-                    print(f"Skipping {vid} due to validation error: {e}")
+                    print(f"Skipping {vid}: {e}")
                     continue
             ids.append(vid)
             docs.append(chunk)
             metadatas.append(meta)
 
     if not docs:
-        print("No valid chunks to upsert after validation")
+        print("No valid chunks to upsert")
         return
 
-    # Attempt upsert
-    try:
-        print(
-            f"Attempting upsert of {len(docs)} chunks to collection '{collection_name}'"
-        )
-        # Some chromadb versions expose upsert, others do not
-        if hasattr(collection, "upsert"):
-            collection.upsert(ids=ids, documents=docs, metadatas=metadatas)
-        else:
-            # fallback: delete then add
-            try:
-                collection.delete(ids=ids)
-            except Exception:
-                pass
-            collection.add(ids=ids, documents=docs, metadatas=metadatas)
-        if not cloud_key:
-            try:
-                client.persist()
-            except Exception:
-                pass
-        print("Upsert completed")
-    except Exception as e:
-        raise SystemExit(f"Failed to upsert to Chroma: {e}")
+    print(f"Upserting {len(docs)} chunks to '{COLLECTION_NAME}'")
+    if hasattr(collection, "upsert"):
+        collection.upsert(ids=ids, documents=docs, metadatas=metadatas)
+    else:
+        try:
+            collection.delete(ids=ids)
+        except Exception:
+            pass
+        collection.add(ids=ids, documents=docs, metadatas=metadatas)
+    if not cloud_key:
+        try:
+            client.persist()
+        except Exception:
+            pass
+    print("Upsert completed")
 
 
 if __name__ == "__main__":

--- a/services/chroma/README.md
+++ b/services/chroma/README.md
@@ -1,43 +1,41 @@
 # Chroma Service
 
-This folder contains a dedicated service for building and persisting a Chroma vector index for SouthOfTethys.
+Builds and persists a Chroma vector index over **canonical** SouthOfTethys lore.
 
-Usage
+## Source of truth
 
-- Build the service via the top-level docker-compose (recommended):
-  ```bash
-  docker compose -f docker-compose.chroma.yml up --build
-  ```
+Indexes:
 
-- The service expects the repository mounted into `/app/repo` and writes Chroma storage to `/data/chroma`.
+- `database/characters|events|fauna|flora|settlements|regions|artifacts|factions|mythology/*.json`
+- optional `snippets/inbox/*`
 
-Environment variables
+Legacy `characters/` and `timeline/` paths are **not** used.
 
-- `REPO_DIR` — path to the repo inside container (default: `/app/repo`).
-- `CHROMA_PERSIST_DIR` — path to persist Chroma store (default: `/data/chroma`).
-- `EMBEDDING_MODEL` — sentence-transformers model to use.
+## Run
 
-Cloud integration
-
-The indexer supports Chroma Cloud. To use it, set the following env vars instead of local persistence:
-
-- `CHROMA_CLOUD_API_KEY` — your Chroma Cloud API key (store securely, do not commit).
-- `CHROMA_TENANT` — optional tenant id for your cloud account.
-- `CHROMA_DATABASE` — optional database name (provider-specific).
-
-Example (docker compose override):
-
-```yaml
-  chroma-service:
-    environment:
-      - CHROMA_CLOUD_API_KEY=${CHROMA_CLOUD_API_KEY}
-      - CHROMA_TENANT=${CHROMA_TENANT}
-      - CHROMA_DATABASE=${CHROMA_DATABASE}
+```bash
+docker compose -f docker-compose.chroma.yml up --build
 ```
-  api_key='ck-3XH4nLsfNauyyYX2DJHuM8rLudPKqz1gv6Gt6pTcQrue',
-  tenant='8241b0e6-7d0b-41dd-946a-b8954d50714e',
-  database='Lemuria'
- ``` 
-Notes
 
-- Back up `/data/chroma` regularly. The index is not committed to git.
+Env:
+
+| Variable | Default | Role |
+|----------|---------|------|
+| `REPO_DIR` | `/app/repo` | Repo mount |
+| `CHROMA_PERSIST_DIR` | `/data/chroma` | Local store |
+| `EMBEDDING_MODEL` | `all-MiniLM-L6-v2` | Embeddings |
+| `CHROMA_CLOUD_API_KEY` | — | Use Chroma Cloud |
+| `CHROMA_TENANT` | — | Cloud tenant |
+| `CHROMA_DATABASE` | — | Cloud DB |
+| `INSERT_VALIDATE` | — | Validate metadata before insert |
+
+## Incremental upsert
+
+```bash
+python scripts/index_changes.py --files database/characters/character_kavik.json
+python scripts/index_changes.py --git-range HEAD~1..HEAD
+```
+
+Collection name: `southoftethys`.
+
+Back up `/data/chroma` regularly; the index is not committed to git.

--- a/services/chroma/index_chroma_service.py
+++ b/services/chroma/index_chroma_service.py
@@ -1,53 +1,173 @@
 """
-Dedicated Chroma indexer service
+Dedicated Chroma indexer service.
 
-This script is intended to run inside the `services/chroma` container and will build/update a persistent
-Chroma index at the path pointed to by `CHROMA_PERSIST_DIR` (default: `/data/chroma`).
-
-It reads story files from the repository mounted into `/app/repo` and writes Chroma storage to `/data/chroma`.
+Indexes canonical lore from database/**/*.json (and optional snippets/inbox).
+Persists to CHROMA_PERSIST_DIR or Chroma Cloud when API key is set.
 """
+
+from __future__ import annotations
+
+import json
 import os
 from pathlib import Path
-from typing import List
+from typing import Any
 
 try:
     import chromadb
     from chromadb.config import Settings
     from sentence_transformers import SentenceTransformer
 except Exception:
-    raise SystemExit("Required packages missing. Make sure to install requirements.txt")
+    raise SystemExit(
+        "Required packages missing. Install chromadb and sentence-transformers."
+    )
 
 _VALIDATE = False
 try:
     from services.chroma.schemas.validate_metadata import validate as validate_metadata
+
     _VALIDATE = True
 except Exception:
-    # validator is optional; controlled by INSERT_VALIDATE env var at runtime
     _VALIDATE = False
 
-# Service defaults
 REPO_DIR = os.environ.get("REPO_DIR", "/app/repo")
 CHROMA_PERSIST_DIR = os.environ.get("CHROMA_PERSIST_DIR", "/data/chroma")
 EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+COLLECTION_NAME = "southoftethys"
+
+# Canon folders under database/
+DB_FOLDERS = [
+    "characters",
+    "events",
+    "fauna",
+    "flora",
+    "settlements",
+    "regions",
+    "artifacts",
+    "factions",
+    "mythology",
+]
 
 
-def gather_text_files(repo_root: Path) -> List[Path]:
-    candidates = []
-    for folder in [repo_root / "timeline", repo_root / "characters", repo_root / "snippets" / "inbox"]:
-        if folder.exists():
-            for p in folder.rglob("*.json"):
-                candidates.append(p)
-            for p in folder.rglob("*.md"):
-                candidates.append(p)
+def gather_files(repo_root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    db = repo_root / "database"
+    if db.exists():
+        for folder in DB_FOLDERS:
+            d = db / folder
+            if d.exists():
+                candidates.extend(sorted(d.glob("*.json")))
+        index = db / "index.json"
+        if index.exists():
+            candidates.append(index)
+    # Optional inbox for raw extraction snippets
+    inbox = repo_root / "snippets" / "inbox"
+    if inbox.exists():
+        candidates.extend(sorted(inbox.rglob("*.md")))
+        candidates.extend(sorted(inbox.rglob("*.txt")))
+        candidates.extend(sorted(inbox.rglob("*.json")))
     return candidates
 
 
-def chunk_text(text: str, chunk_size: int = 512) -> List[str]:
+def chunk_text(text: str, chunk_size: int = 200) -> list[str]:
     words = text.split()
-    chunks = []
-    for i in range(0, len(words), chunk_size):
-        chunks.append(" ".join(words[i:i+chunk_size]))
-    return chunks
+    if not words:
+        return [text] if text.strip() else []
+    return [
+        " ".join(words[i : i + chunk_size]) for i in range(0, len(words), chunk_size)
+    ]
+
+
+def entity_document(payload: dict[str, Any]) -> str:
+    """Flatten entity JSON into searchable prose."""
+    parts: list[str] = []
+    for key in (
+        "id",
+        "type",
+        "name",
+        "title",
+        "epithets",
+        "aliases",
+        "culture",
+        "species",
+        "epoch",
+        "status",
+        "roles",
+        "summary",
+        "notes",
+        "diet",
+        "habitats",
+        "behaviour",
+        "uses",
+        "power",
+        "risk",
+        "material",
+    ):
+        val = payload.get(key)
+        if val is None or val == "" or val == []:
+            continue
+        if isinstance(val, list):
+            parts.append(f"{key}: {', '.join(str(v) for v in val)}")
+        else:
+            parts.append(f"{key}: {val}")
+    # relations / graph fields
+    for key in (
+        "relations",
+        "participants",
+        "predecessors",
+        "successors",
+        "outcomes",
+        "causes",
+        "related_characters",
+        "events",
+        "artifacts",
+    ):
+        val = payload.get(key)
+        if not val:
+            continue
+        if isinstance(val, dict):
+            parts.append(f"{key}: {json.dumps(val, ensure_ascii=False)}")
+        elif isinstance(val, list):
+            parts.append(f"{key}: {', '.join(str(v) for v in val)}")
+        else:
+            parts.append(f"{key}: {val}")
+    return "\n".join(parts) if parts else json.dumps(payload, ensure_ascii=False)
+
+
+def build_metadata(repo_root: Path, fpath: Path, payload: dict | None, chunk_index: int):
+    rel = str(fpath.relative_to(repo_root))
+    meta: dict[str, Any] = {"source": rel, "chunk_index": chunk_index}
+    if payload and isinstance(payload, dict):
+        eid = payload.get("id") or fpath.stem
+        meta["entity_id"] = eid
+        meta["entity_type"] = payload.get("type") or fpath.parent.name.rstrip("s")
+        if payload.get("name"):
+            meta["name"] = payload["name"]
+        if payload.get("title"):
+            meta["title"] = payload["title"]
+        if payload.get("epoch"):
+            meta["epoch"] = payload["epoch"]
+        if payload.get("culture"):
+            meta["culture"] = payload["culture"]
+    else:
+        meta["entity_id"] = fpath.stem
+    return meta
+
+
+def get_client():
+    cloud_key = os.environ.get("CHROMA_CLOUD_API_KEY")
+    if cloud_key:
+        tenant = os.environ.get("CHROMA_TENANT")
+        database = os.environ.get("CHROMA_DATABASE")
+        return chromadb.CloudClient(
+            api_key=cloud_key, tenant=tenant, database=database
+        ), True
+    client = chromadb.Client(
+        Settings(
+            chroma_db_impl="duckdb+parquet",
+            persist_directory=CHROMA_PERSIST_DIR,
+        )
+    )
+    return client, False
 
 
 def main():
@@ -55,86 +175,73 @@ def main():
     if not repo_root.exists():
         raise SystemExit(f"Repo directory not found: {REPO_DIR}")
 
-    # Support Chroma Cloud if API key provided, otherwise use local DuckDB+Parquet persistence
-    cloud_key = os.environ.get("CHROMA_CLOUD_API_KEY")
-    collection_name = "southoftethys"
-    if cloud_key:
-        # Use CloudClient for remote Chroma; tenant and database may be provider specific
-        tenant = os.environ.get("CHROMA_TENANT")
-        database = os.environ.get("CHROMA_DATABASE")
-        client = chromadb.CloudClient(api_key=cloud_key, tenant=tenant, database=database)
-        try:
-            # recreate collection if exists
-            client.delete_collection(collection_name)
-        except Exception:
-            pass
-        collection = client.create_collection(collection_name)
-    else:
-        client = chromadb.Client(Settings(chroma_db_impl="duckdb+parquet", persist_directory=CHROMA_PERSIST_DIR))
-        try:
-            # Recreate collection for fresh index
-            client.delete_collection(collection_name)
-        except Exception:
-            pass
-        collection = client.create_collection(collection_name)
+    client, is_cloud = get_client()
+    try:
+        client.delete_collection(COLLECTION_NAME)
+    except Exception:
+        pass
+    collection = client.create_collection(COLLECTION_NAME)
 
-    embedder = SentenceTransformer(EMBEDDING_MODEL)
-    files = gather_text_files(repo_root)
+    # Load embedder so model is warm (chromadb may also embed depending on config)
+    SentenceTransformer(EMBEDDING_MODEL)
+
+    files = gather_files(repo_root)
     ids, docs, metadatas = [], [], []
+
     for f in files:
-        text = f.read_text(encoding="utf-8")
+        raw = f.read_text(encoding="utf-8")
+        payload = None
+        if f.suffix == ".json":
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                payload = None
+            text = (
+                entity_document(payload)
+                if isinstance(payload, dict)
+                else raw
+            )
+        else:
+            text = raw
+
         chunks = chunk_text(text, chunk_size=200)
         for ci, chunk in enumerate(chunks):
             vid = f"{f.stem}_{ci}"
+            meta = build_metadata(repo_root, f, payload if isinstance(payload, dict) else None, ci)
+
+            if os.environ.get("INSERT_VALIDATE") and _VALIDATE:
+                coll = meta.get("entity_type", "documents")
+                if coll in {"character", "characters"}:
+                    coll = "characters"
+                elif coll in {"event", "events"}:
+                    coll = "events"
+                else:
+                    coll = "documents"
+                try:
+                    validate_metadata(
+                        coll, {"id": vid, "text": chunk, "metadata": meta}
+                    )
+                except Exception as e:
+                    print(f"Validation failed for {vid}: {e}")
+                    continue
+
             ids.append(vid)
             docs.append(chunk)
-            # build richer metadata depending on folder
-            rel = str(f.relative_to(repo_root))
-            meta = {"source": rel, "chunk_index": ci}
-            if rel.startswith("timeline/"):
-                # try to pull event_id/title/date from json if available
-                try:
-                    import json
-                    payload = json.loads(text)
-                    event_id = payload.get("id") or f.stem
-                    meta.update({"event_id": event_id, "title": payload.get("title"), "date": payload.get("date")})
-                except Exception:
-                    meta.update({"event_id": f.stem})
-            elif rel.startswith("characters/"):
-                try:
-                    import json
-                    payload = json.loads(text)
-                    char_id = payload.get("id") or f.stem
-                    meta.update({"character_id": char_id, "name": payload.get("name") or payload.get("id")})
-                except Exception:
-                    meta.update({"character_id": f.stem, "name": f.stem})
-            elif rel.startswith("snippets/"):
-                meta.update({"snippet_id": f.stem})
-
-            # optional validation before adding
-            if os.environ.get("INSERT_VALIDATE") and _VALIDATE:
-                coll = None
-                if rel.startswith("timeline/"):
-                    coll = "events"
-                elif rel.startswith("characters/"):
-                    coll = "characters"
-                elif rel.startswith("snippets/"):
-                    coll = "snippets"
-                if coll:
-                    try:
-                        validate_metadata(coll, {"id": vid, "text": chunk, "metadata": meta})
-                    except Exception as e:
-                        print(f"Validation failed for {vid}: {e}")
-                        continue
-
             metadatas.append(meta)
 
     if docs:
         collection.add(ids=ids, documents=docs, metadatas=metadatas)
-        client.persist()
-        print(f"Indexed {len(docs)} chunks into Chroma at {CHROMA_PERSIST_DIR}")
+        if not is_cloud:
+            try:
+                client.persist()
+            except Exception:
+                pass
+        print(
+            f"Indexed {len(docs)} chunks from {len(files)} files "
+            f"into '{COLLECTION_NAME}'"
+        )
     else:
-        print("No documents found to index.")
+        print("No documents found to index under database/.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Next package after PR #21: wire Chroma to canonical `database/` and land P0 artifacts.

### Chroma
- `services/chroma/index_chroma_service.py` indexes `database/**/*.json` (not legacy paths)
- Flattened entity text for better retrieval; metadata includes `entity_id`, `entity_type`, `name`/`title`, `epoch`, `culture`
- `scripts/index_changes.py` prefers `database/` + `snippets/`
- README updated

### Canon (v0.8.0)
- `artifact_mask_of_tethys` (Vijaya / Tamralinga)
- `artifact_mask_of_sunlit_stone` (Mask Family relic)
- `database/index.json` bumped (3 artifacts)

### Still open
- Portal smoke-test (local)
- P1: Narmada University + scholars faction
- Vijaya / Mask of Tethys event node