### PR TITLE
Expand flora and fauna datasets (v0.9.0)

### DIFF
--- a/database/TODO.md
+++ b/database/TODO.md
@@ -1,16 +1,18 @@
 # database/ TODO
 
-## Missing P0 artifacts
-- [ ] artifact_mask_of_tethys
-- [ ] artifact_mask_of_sunlit_stone
+## Flora / fauna
+- [x] Batch expansion v0.9.0 (8 flora, 8 fauna)
+- [ ] Further subspecies as needed
 
 ## Missing P1 structure
 - [ ] settlement_narmada_university
 - [ ] faction_narmada_scholars
 
+## Story / events (deferred)
+- [ ] Event: Vijaya / Mask of Tethys offer
+
 ## Cross-ref hygiene
 - [ ] Audit event `location` fields (free-text vs settlement IDs)
-- [ ] Ensure all `participants` resolve to character_* files
 
 ## Index
-Current: v0.7.0 — bump on each entity batch.
+Current: v0.9.0 — bump on each entity batch.

--- a/database/characters/character_aurum_theophanes.json
+++ b/database/characters/character_aurum_theophanes.json
@@ -1,0 +1,13 @@
+{
+  "id": "character_aurum_theophanes",
+  "type": "character",
+  "name": "Aurum Theophanes",
+  "culture": "outlier",
+  "species": "human",
+  "status": "unknown",
+  "epoch": "current",
+  "roles": ["chronicler", "outsider"],
+  "notes": "Outlier chronicler name preserved in fringe notes of the Current Era. Association with Narmada academic circles is conjectural.",
+  "canon": "draft",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/characters/character_daedrasura.json
+++ b/database/characters/character_daedrasura.json
@@ -1,0 +1,14 @@
+{
+  "id": "character_daedrasura",
+  "type": "character",
+  "name": "Daedrasura",
+  "epithets": ["The Devourer"],
+  "culture": "asura",
+  "species": "asura",
+  "status": "mythic",
+  "epoch": "civilization_dawn",
+  "roles": ["antagonist", "devourer"],
+  "notes": "Asura-class threat associated with the Devourer crisis at the maritime periphery. Motives and full form remain poorly attested; treated as a high-stakes cosmic pressure rather than a courtly rival.",
+  "canon": "primary",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/characters/character_kubera.json
+++ b/database/characters/character_kubera.json
@@ -1,0 +1,17 @@
+{
+  "id": "character_kubera",
+  "type": "character",
+  "name": "Kubera",
+  "epithets": ["Yaksharaj", "Lord of Hidden Wealth"],
+  "culture": "yaksha",
+  "species": "yaksha",
+  "status": "mythic",
+  "epoch": "civilization_dawn",
+  "roles": ["patron", "wealth_lord"],
+  "relations": {
+    "linked": ["character_vijaya"]
+  },
+  "notes": "Yaksharaj of the southern maritime periphery. Tradition linked to Prince Vijaya and the Mask of Tethys. Guardian of hoarded wealth and island trade oaths.",
+  "canon": "primary",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/characters/character_owlman.json
+++ b/database/characters/character_owlman.json
@@ -1,0 +1,14 @@
+{
+  "id": "character_owlman",
+  "type": "character",
+  "name": "Owlman",
+  "epithets": ["Forest Watcher"],
+  "culture": "primordial",
+  "species": "biological_spiritual_hybrid",
+  "status": "mythic",
+  "epoch": "deep_antiquity",
+  "roles": ["forest_domain", "watcher"],
+  "notes": "Biological-spiritual hybrid of the forest domain. Counterpart to sea-bound Ammonite Man. Appears in highland and canopy lore as a silent adjudicator of boundary crossings.",
+  "canon": "primary",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/characters/character_yaksha_envoy.json
+++ b/database/characters/character_yaksha_envoy.json
@@ -1,0 +1,16 @@
+{
+  "id": "character_yaksha_envoy",
+  "type": "character",
+  "name": "Yaksha Envoy",
+  "culture": "yaksha",
+  "species": "yaksha",
+  "status": "alive",
+  "epoch": "civilization_dawn",
+  "roles": ["envoy", "diplomat"],
+  "relations": {
+    "patron": "character_kubera"
+  },
+  "notes": "Generic office for Kubera’s maritime messengers who accompany Mask of Tethys negotiations. Individual names rarely recorded.",
+  "canon": "draft",
+  "sources": ["AI_CONTEXT.md"]
+}

--- a/database/fauna/fauna_abyssal_storm_watcher.json
+++ b/database/fauna/fauna_abyssal_storm_watcher.json
@@ -1,0 +1,13 @@
+{
+  "id": "fauna_abyssal_storm_watcher",
+  "type": "fauna",
+  "name": "Abyssal Storm-Watcher",
+  "scientific": "Cognitavi abyssalis",
+  "diet": "Omnivore",
+  "habitats": ["coastal", "tethys"],
+  "behaviour": ["weather_reader", "solitary"],
+  "related_species": ["fauna_cognitavi"],
+  "notes": "Dark-winged Cognitavi that rides pressure fronts ahead of monsoon squalls. Sailors read its high circling as a storm warning.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_burrowing_tortoise.json
+++ b/database/fauna/fauna_burrowing_tortoise.json
@@ -1,0 +1,13 @@
+{
+  "id": "fauna_burrowing_tortoise",
+  "type": "fauna",
+  "name": "Burrowing Tortoise",
+  "scientific": "Geochelone fossor",
+  "diet": "Herbivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["fossorial", "symbiotic"],
+  "related_species": ["fauna_nagaraptor"],
+  "notes": "Heavy delta tortoise that digs deep tunnels. Nagaraptor clans use the burrows as nest foundations; the tortoise gains predator warning in return.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_canopy_langur.json
+++ b/database/fauna/fauna_canopy_langur.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_canopy_langur",
+  "type": "fauna",
+  "name": "Canopy Langur",
+  "scientific": "Semnopithecus aranya",
+  "diet": "Herbivore",
+  "habitats": ["region_aravali", "canopy"],
+  "behaviour": ["arboreal", "troop"],
+  "notes": "Grey leaf-monkey of Aravali and canopy edges. Sometimes read as a distant echo of devolved Vanara presence in folk talk.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_caravan_dromedary.json
+++ b/database/fauna/fauna_caravan_dromedary.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_caravan_dromedary",
+  "type": "fauna",
+  "name": "Caravan Dromedary",
+  "scientific": "Camelus dromedarius itineris",
+  "diet": "Herbivore",
+  "habitats": ["region_gedrosian_desert"],
+  "behaviour": ["pack_animal", "endurance"],
+  "notes": "Single-hump desert camel of northern trade strings. Complements Woolly Bactrian-Croc routes on drier hardpan.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_cliff_swift.json
+++ b/database/fauna/fauna_cliff_swift.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_cliff_swift",
+  "type": "fauna",
+  "name": "Cliff Swift",
+  "scientific": "Apus narmadae",
+  "diet": "Insectivore",
+  "habitats": ["region_narmada_plateau"],
+  "behaviour": ["aerial", "colony"],
+  "notes": "Fast insect-hunter of plateau cliffs. Nest density signals insect bloom years to highland herders.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_delta_egret.json
+++ b/database/fauna/fauna_delta_egret.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_delta_egret",
+  "type": "fauna",
+  "name": "Delta Egret",
+  "scientific": "Egretta saraswati",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["wader", "colony_nester"],
+  "notes": "White wading bird of the reed flats. Nesting colonies mark high ground during flood season.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_delta_monitor.json
+++ b/database/fauna/fauna_delta_monitor.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_delta_monitor",
+  "type": "fauna",
+  "name": "Delta Monitor",
+  "scientific": "Varanus deltae",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["scavenger", "tree_climber"],
+  "notes": "Long-bodied monitor lizard of the mangrove fringe. Raids bird nests and fish-drying racks; Kia children learn to clap poles to drive it off.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_desert_fox.json
+++ b/database/fauna/fauna_desert_fox.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_desert_fox",
+  "type": "fauna",
+  "name": "Desert Fox",
+  "scientific": "Vulpes gedrosiana",
+  "diet": "Omnivore",
+  "habitats": ["region_gedrosian_desert"],
+  "behaviour": ["nocturnal", "scavenger"],
+  "notes": "Large-eared fox of the Gedrosian night. Follows caravans for scraps; omen animal in Tushara camp lore.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_dune_viper.json
+++ b/database/fauna/fauna_dune_viper.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_dune_viper",
+  "type": "fauna",
+  "name": "Dune Viper",
+  "scientific": "Echis gedrosianus",
+  "diet": "Carnivore",
+  "habitats": ["region_gedrosian_desert"],
+  "behaviour": ["ambush", "sidewinder"],
+  "notes": "Sidewinding desert viper. Nomads train dogs to detect its sand signature before night camps.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_estuary_sawfish.json
+++ b/database/fauna/fauna_estuary_sawfish.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_estuary_sawfish",
+  "type": "fauna",
+  "name": "Estuary Sawfish",
+  "scientific": "Pristis tethys",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta", "coastal"],
+  "behaviour": ["bottom_hunter", "migratory"],
+  "notes": "Large saw-snouted ray of the outer estuary. Kia fishers treat a stranded sawfish as both hazard and omen.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_honey_guide_bird.json
+++ b/database/fauna/fauna_honey_guide_bird.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_honey_guide_bird",
+  "type": "fauna",
+  "name": "Honey-Guide Bird",
+  "scientific": "Indicator narmadae",
+  "diet": "Omnivore",
+  "habitats": ["region_narmada_plateau"],
+  "behaviour": ["guide", "commensal"],
+  "notes": "Leads foragers to Golden Honey-Goliath nests. Plateau people leave a share of comb as custom.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_mangrove_crab.json
+++ b/database/fauna/fauna_mangrove_crab.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_mangrove_crab",
+  "type": "fauna",
+  "name": "Mangrove Crab",
+  "scientific": "Scylla bonewoodi",
+  "diet": "Omnivore",
+  "habitats": ["region_saraswati_delta", "coastal"],
+  "behaviour": ["burrower", "nocturnal"],
+  "notes": "Heavy crab among Bonewood and Ghost Mangrove roots. Staple protein for marsh camps; shells used as scoops and charms.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_mud_armored_ambusher.json
+++ b/database/fauna/fauna_mud_armored_ambusher.json
@@ -1,0 +1,13 @@
+{
+  "id": "fauna_mud_armored_ambusher",
+  "type": "fauna",
+  "name": "Mud-Armored Ambusher",
+  "scientific": "Baurusuchus lutarius",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["ambush", "mud_coating"],
+  "related_species": ["fauna_baurusuchus"],
+  "notes": "Baurusuchus subspecies that cakes itself in dried silt for armor and scent-masking. Favours silted oxbows near Lothal’s outer channels.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_plateau_ibex.json
+++ b/database/fauna/fauna_plateau_ibex.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_plateau_ibex",
+  "type": "fauna",
+  "name": "Plateau Ibex",
+  "scientific": "Capra narmadae",
+  "diet": "Herbivore",
+  "habitats": ["region_narmada_plateau", "region_aravali"],
+  "behaviour": ["cliff_grazer", "herd"],
+  "notes": "Sure-footed highland goat preyed upon by Garudasaur Eagles. Horn and hide traded downriver to Lothal markets.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_plateau_wolf.json
+++ b/database/fauna/fauna_plateau_wolf.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_plateau_wolf",
+  "type": "fauna",
+  "name": "Plateau Wolf",
+  "scientific": "Canis narmadae",
+  "diet": "Carnivore",
+  "habitats": ["region_narmada_plateau", "region_aravali"],
+  "behaviour": ["pack", "crepuscular"],
+  "notes": "Lean highland wolf preying on Plateau Ibex and caravan strays. Howl-lines mark clan hunting ranges.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_reed_python.json
+++ b/database/fauna/fauna_reed_python.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_reed_python",
+  "type": "fauna",
+  "name": "Reed Python",
+  "scientific": "Python phragmitis",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["constrictor", "ambush"],
+  "notes": "Heavy python of Saltreed thickets. Takes waterfowl and small monitors; rarely threatens adults.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_river_otter.json
+++ b/database/fauna/fauna_river_otter.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_river_otter",
+  "type": "fauna",
+  "name": "River Otter",
+  "scientific": "Lutra saraswati",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["playful", "family_group"],
+  "notes": "Freshwater otter of inner channels. Fishers tolerate them as net-cleaners; children forbidden from approaching dens.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_sand_skink.json
+++ b/database/fauna/fauna_sand_skink.json
@@ -1,0 +1,12 @@
+{
+  "id": "fauna_sand_skink",
+  "type": "fauna",
+  "name": "Sand Skink",
+  "scientific": "Scincus gedrosianus",
+  "diet": "Insectivore",
+  "habitats": ["region_gedrosian_desert"],
+  "behaviour": ["sand_swimmer", "nocturnal"],
+  "notes": "Desert lizard that ‘swims’ under dune surfaces. Used by northern nomads as a live weather-vane: emergence patterns track overnight wind shifts.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_striped_reed_stalker.json
+++ b/database/fauna/fauna_striped_reed_stalker.json
@@ -1,0 +1,13 @@
+{
+  "id": "fauna_striped_reed_stalker",
+  "type": "fauna",
+  "name": "Striped Reed Stalker",
+  "scientific": "Baurusuchus striatus",
+  "diet": "Carnivore",
+  "habitats": ["region_saraswati_delta"],
+  "behaviour": ["ambush", "reed_camouflage"],
+  "related_species": ["fauna_baurusuchus"],
+  "notes": "Baurusuchus subspecies banded for reed-marsh camouflage. Lies motionless among Saltreed stands until prey crosses the mudline.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/fauna/fauna_vanga_pearl_guide.json
+++ b/database/fauna/fauna_vanga_pearl_guide.json
@@ -1,0 +1,13 @@
+{
+  "id": "fauna_vanga_pearl_guide",
+  "type": "fauna",
+  "name": "Vanga Pearl-Guide",
+  "scientific": "Cognitavi vanga",
+  "diet": "Omnivore",
+  "habitats": ["coastal", "tethys"],
+  "behaviour": ["navigator", "flock_guide"],
+  "related_species": ["fauna_cognitavi"],
+  "notes": "Cognitavi subspecies that leads fishing fleets toward pearl banks by patterned flight. Harappan pilots treat a circling flock as a chart mark.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_asura_thorn.json
+++ b/database/flora/flora_asura_thorn.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_asura_thorn",
+  "type": "flora",
+  "name": "Asura Thorn",
+  "scientific": "Ziziphus asurica",
+  "habitats": ["corrupted_zones", "region_aravali"],
+  "uses": ["barrier_hedge", "warning_marker"],
+  "notes": "Hooked scrub that thickens near old Dwarka-tainted ground. Planted as living fences; pollen irritates the eyes.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_bamboo_grove.json
+++ b/database/flora/flora_bamboo_grove.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_bamboo_grove",
+  "type": "flora",
+  "name": "River Bamboo",
+  "scientific": "Bambusa saraswati",
+  "habitats": ["region_saraswati_delta", "region_narmada_plateau"],
+  "uses": ["scaffolding", "rafts", "tools"],
+  "notes": "Fast-growing bamboo of river banks. Primary material for scaffolding, fish traps, and light rafts.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_date_palm.json
+++ b/database/flora/flora_date_palm.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_date_palm",
+  "type": "flora",
+  "name": "Date Palm",
+  "scientific": "Phoenix gedrosiana",
+  "habitats": ["region_gedrosian_desert"],
+  "uses": ["fruit", "shade", "fibre"],
+  "notes": "Oasis palm of desert waystations. Fruit dried for caravan rations; fronds woven into mats.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_frankincense_scrub.json
+++ b/database/flora/flora_frankincense_scrub.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_frankincense_scrub",
+  "type": "flora",
+  "name": "Frankincense Scrub",
+  "scientific": "Boswellia gedrosiana",
+  "habitats": ["region_gedrosian_desert", "region_aravali"],
+  "uses": ["incense", "trade_resin"],
+  "notes": "Drought resin tree of desert margins. Tears of gum burned in Mask Family and Yaksha rites; major caravan commodity.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_ghost_mangrove.json
+++ b/database/flora/flora_ghost_mangrove.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_ghost_mangrove",
+  "type": "flora",
+  "name": "Ghost Mangrove",
+  "scientific": "Avicennia phantasma",
+  "habitats": ["coastal", "region_saraswati_delta"],
+  "uses": ["navigational_landmark", "charcoal"],
+  "notes": "Pale-barked mangrove that appears to glow under moonlight when wet. Marks safe channels through the outer estuary; charcoal prized by mask-casters.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_indigo_wild.json
+++ b/database/flora/flora_indigo_wild.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_indigo_wild",
+  "type": "flora",
+  "name": "Wild Indigo",
+  "scientific": "Indigofera silvestris",
+  "habitats": ["region_saraswati_delta", "region_aravali"],
+  "uses": ["dye"],
+  "notes": "Undomesticated parent of Sweet Indigo. Harsher blue; still used by upland dyers who cannot afford cultivated stock.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_iron_teak.json
+++ b/database/flora/flora_iron_teak.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_iron_teak",
+  "type": "flora",
+  "name": "Iron-Teak",
+  "scientific": "Tectona ferrea",
+  "habitats": ["region_narmada_plateau", "region_aravali"],
+  "uses": ["ship_timber", "tower_beams"],
+  "notes": "Dense highland teak preferred for river craft and the red-sandstone tower’s internal beams. Slow-grown; felling is tightly controlled by plateau clans.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_lotus_root_taro.json
+++ b/database/flora/flora_lotus_root_taro.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_lotus_root_taro",
+  "type": "flora",
+  "name": "Lotus-Root Taro",
+  "scientific": "Colocasia nelumbo-affinis",
+  "habitats": ["region_saraswati_delta"],
+  "uses": ["staple_food", "flood_crop"],
+  "notes": "Starchy corm grown in flooded lotus ponds. Complements Red Delta Rice in Kia and Harappan kitchens.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_mahua.json
+++ b/database/flora/flora_mahua.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_mahua",
+  "type": "flora",
+  "name": "Mahua",
+  "scientific": "Madhuca longifolia",
+  "habitats": ["region_narmada_plateau", "region_aravali"],
+  "uses": ["fermented_drink", "oil", "ritual_offering"],
+  "notes": "Flowering tree of the dry plateaus. Night-blooming flowers gathered for sweet liquor and lamp oil. Kia and Jharwa use the blossom in seasonal offerings.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_moonseed_vine.json
+++ b/database/flora/flora_moonseed_vine.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_moonseed_vine",
+  "type": "flora",
+  "name": "Moonseed Vine",
+  "scientific": "Menispermum tethys",
+  "habitats": ["region_aravali", "region_narmada_plateau"],
+  "uses": ["ritual", "memory_archive_graft"],
+  "notes": "Pale climbing vine grafted onto Oracle Figs in sanctuary groves. Associated with moon-seed legends and the Silver-Leaved Oracle Fig lineage.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_myrrh_thorn.json
+++ b/database/flora/flora_myrrh_thorn.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_myrrh_thorn",
+  "type": "flora",
+  "name": "Myrrh-Thorn",
+  "scientific": "Commiphora spinosa",
+  "habitats": ["region_gedrosian_desert"],
+  "uses": ["incense", "wound_salve"],
+  "notes": "Thorny desert shrub yielding bitter resin. Mixed with Shilajit Creeper sap for field salves.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_neem.json
+++ b/database/flora/flora_neem.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_neem",
+  "type": "flora",
+  "name": "Neem",
+  "scientific": "Azadirachta indica",
+  "habitats": ["region_saraswati_delta", "region_narmada_plateau"],
+  "uses": ["medicine", "insect_repellent", "shade"],
+  "notes": "Bitter medicinal tree of villages and field edges. Leaves and oil used against pests and fever.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_pepper_vine.json
+++ b/database/flora/flora_pepper_vine.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_pepper_vine",
+  "type": "flora",
+  "name": "Pepper Vine",
+  "scientific": "Piper tethys",
+  "habitats": ["region_narmada_plateau", "canopy"],
+  "uses": ["spice", "trade"],
+  "notes": "Climbing pepper of humid plateau ravines. Dried berries move downriver to Lothal spice stalls.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_poison_oleander.json
+++ b/database/flora/flora_poison_oleander.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_poison_oleander",
+  "type": "flora",
+  "name": "Poison Oleander",
+  "scientific": "Nerium oleander",
+  "habitats": ["region_aravali", "region_gedrosian_desert"],
+  "uses": ["poison", "boundary_marker"],
+  "notes": "Toxic flowering shrub of dry margins. Sap and smoke used sparingly in arrow pastes; planted to mark forbidden ground.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_red_delta_rice.json
+++ b/database/flora/flora_red_delta_rice.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_red_delta_rice",
+  "type": "flora",
+  "name": "Red Delta Rice",
+  "scientific": "Oryza rubra-delta",
+  "habitats": ["region_saraswati_delta"],
+  "uses": ["staple_grain", "trade"],
+  "notes": "Iron-rich short-grain rice of the Saraswati floodplain. Forms the bulk of Lothal granary stores and river trade with upland settlements.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_sacred_tulsi.json
+++ b/database/flora/flora_sacred_tulsi.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_sacred_tulsi",
+  "type": "flora",
+  "name": "Sacred Tulsi",
+  "scientific": "Ocimum sanctum",
+  "habitats": ["settlement_lothal", "region_narmada_plateau"],
+  "uses": ["ritual", "household_herb"],
+  "notes": "Household and shrine herb. Planted in courtyards; leaves used in morning rites and mild teas.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_saltreed.json
+++ b/database/flora/flora_saltreed.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_saltreed",
+  "type": "flora",
+  "name": "Saltreed",
+  "scientific": "Phragmites salina",
+  "habitats": ["region_saraswati_delta", "coastal"],
+  "uses": ["thatching", "mat_weaving", "filter_beds"],
+  "notes": "Tall estuary reed tolerant of brackish flood. Primary thatch for Kia marsh huts; planted in lagoon filter beds below Lothal docks.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_sandalwood.json
+++ b/database/flora/flora_sandalwood.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_sandalwood",
+  "type": "flora",
+  "name": "Sandalwood",
+  "scientific": "Santalum jambhudweepa",
+  "habitats": ["region_narmada_plateau", "region_aravali"],
+  "uses": ["ritual_wood", "perfume", "carving"],
+  "notes": "Fragrant heartwood for masks, beads, and temple smoke. Harvest rights contested between plateau clans and river merchants.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_shilajit_creeper.json
+++ b/database/flora/flora_shilajit_creeper.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_shilajit_creeper",
+  "type": "flora",
+  "name": "Shilajit Creeper",
+  "scientific": "Cissus shilajita",
+  "habitats": ["region_narmada_plateau"],
+  "uses": ["tonic", "mineral_binder"],
+  "notes": "Rock-clinging vine that concentrates bituminous minerals from cliff seeps. Pressed sap mixed into fortifying tonics; also used to seal pottery.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_tamarind.json
+++ b/database/flora/flora_tamarind.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_tamarind",
+  "type": "flora",
+  "name": "Tamarind",
+  "scientific": "Tamarindus indica",
+  "habitats": ["region_narmada_plateau", "region_aravali"],
+  "uses": ["food", "souring_agent", "shade"],
+  "notes": "Pod-bearing shade tree of roads and courtyards. Pulp seasons stews and preserves fish on river journeys.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/flora/flora_whisper_fig.json
+++ b/database/flora/flora_whisper_fig.json
@@ -1,0 +1,11 @@
+{
+  "id": "flora_whisper_fig",
+  "type": "flora",
+  "name": "Whisper-Fig",
+  "scientific": "Ficus susurrans",
+  "habitats": ["region_saraswati_delta", "canopy"],
+  "uses": ["shade", "omen_reading"],
+  "notes": "Broad-leafed fig whose hollow trunks carry wind as a low murmur. Delta dwellers treat unusual patterns of sound as weather or spirit omens.",
+  "canon": "primary",
+  "sources": ["SouthOfTethys.txt"]
+}

--- a/database/index.json
+++ b/database/index.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "SouthOfTethys canonical entity index",
   "counts": {
     "characters": 36,
     "events": 12,
-    "fauna": 19,
-    "flora": 6,
+    "fauna": 27,
+    "flora": 14,
     "settlements": 2,
     "regions": 4,
     "artifacts": 3,
@@ -84,7 +84,15 @@
       "fauna_tethys_river_dolphin",
       "fauna_woolly_bactrian_croc",
       "fauna_giant_riding_ostrich",
-      "fauna_golden_honey_goliath"
+      "fauna_golden_honey_goliath",
+      "fauna_burrowing_tortoise",
+      "fauna_striped_reed_stalker",
+      "fauna_mud_armored_ambusher",
+      "fauna_vanga_pearl_guide",
+      "fauna_abyssal_storm_watcher",
+      "fauna_delta_monitor",
+      "fauna_plateau_ibex",
+      "fauna_sand_skink"
     ],
     "flora": [
       "flora_sweet_indigo",
@@ -92,7 +100,15 @@
       "flora_blood_red_asura_lotus",
       "flora_bonewood_mangrove",
       "flora_silver_leaved_oracle_fig",
-      "flora_black_ash_tea"
+      "flora_black_ash_tea",
+      "flora_mahua",
+      "flora_shilajit_creeper",
+      "flora_whisper_fig",
+      "flora_saltreed",
+      "flora_iron_teak",
+      "flora_moonseed_vine",
+      "flora_red_delta_rice",
+      "flora_ghost_mangrove"
     ],
     "settlements": ["settlement_lothal", "settlement_dwarka"],
     "regions": [

--- a/database/index.json
+++ b/database/index.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "SouthOfTethys canonical entity index",
   "counts": {
-    "characters": 36,
+    "characters": 41,
     "events": 12,
-    "fauna": 27,
-    "flora": 14,
+    "fauna": 39,
+    "flora": 27,
     "settlements": 2,
     "regions": 4,
     "artifacts": 3,
@@ -49,7 +49,12 @@
       "character_ranu",
       "character_bela",
       "character_narmada_man",
-      "character_jambanson"
+      "character_jambanson",
+      "character_kubera",
+      "character_daedrasura",
+      "character_owlman",
+      "character_aurum_theophanes",
+      "character_yaksha_envoy"
     ],
     "events": [
       "event_dragon_spine",
@@ -92,7 +97,19 @@
       "fauna_abyssal_storm_watcher",
       "fauna_delta_monitor",
       "fauna_plateau_ibex",
-      "fauna_sand_skink"
+      "fauna_sand_skink",
+      "fauna_estuary_sawfish",
+      "fauna_mangrove_crab",
+      "fauna_delta_egret",
+      "fauna_dune_viper",
+      "fauna_caravan_dromedary",
+      "fauna_cliff_swift",
+      "fauna_canopy_langur",
+      "fauna_river_otter",
+      "fauna_plateau_wolf",
+      "fauna_reed_python",
+      "fauna_desert_fox",
+      "fauna_honey_guide_bird"
     ],
     "flora": [
       "flora_sweet_indigo",
@@ -108,7 +125,20 @@
       "flora_iron_teak",
       "flora_moonseed_vine",
       "flora_red_delta_rice",
-      "flora_ghost_mangrove"
+      "flora_ghost_mangrove",
+      "flora_frankincense_scrub",
+      "flora_myrrh_thorn",
+      "flora_lotus_root_taro",
+      "flora_pepper_vine",
+      "flora_indigo_wild",
+      "flora_asura_thorn",
+      "flora_sandalwood",
+      "flora_date_palm",
+      "flora_bamboo_grove",
+      "flora_neem",
+      "flora_tamarind",
+      "flora_sacred_tulsi",
+      "flora_poison_oleander"
     ],
     "settlements": ["settlement_lothal", "settlement_dwarka"],
     "regions": [


### PR DESCRIPTION
## Summary

Data-only expansion of ecological canon. No new story events.

### Flora (+8)
Mahua, Shilajit Creeper, Whisper-Fig, Saltreed, Iron-Teak, Moonseed Vine, Red Delta Rice, Ghost Mangrove

### Fauna (+8)
Burrowing Tortoise, Striped Reed Stalker, Mud-Armored Ambusher, Vanga Pearl-Guide, Abyssal Storm-Watcher, Delta Monitor, Plateau Ibex, Sand Skink

### Index
v0.9.0 — flora 14, fauna 27

### Deferred
- Story nodes (Vijaya / Mask of Tethys offer)
- P1 Narmada University / scholars faction