### PR TITLE
Export canon species to the game; record authored order as canon

### DIFF
--- a/database/fauna/fauna_abyssal_blue_leviathan.json
+++ b/database/fauna/fauna_abyssal_blue_leviathan.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 121
 }

--- a/database/fauna/fauna_abyssal_storm_watcher.json
+++ b/database/fauna/fauna_abyssal_storm_watcher.json
@@ -29,5 +29,6 @@
   "rarity": "common",
   "journal_prompt": "A Cognitavi navigator bird subspecies that specializes in reading weather patterns, guiding wisdom-seekers and ships safely through the Tethys monsoons.",
   "mood": "clever",
-  "sentient": true
+  "sentient": true,
+  "source_index": 16
 }

--- a/database/fauna/fauna_aero_manta_high_altitude_beedu.json
+++ b/database/fauna/fauna_aero_manta_high_altitude_beedu.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 176
 }

--- a/database/fauna/fauna_aero_moth.json
+++ b/database/fauna/fauna_aero_moth.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 191
 }

--- a/database/fauna/fauna_aero_snail.json
+++ b/database/fauna/fauna_aero_snail.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 186
 }

--- a/database/fauna/fauna_aero_weevil.json
+++ b/database/fauna/fauna_aero_weevil.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 201
 }

--- a/database/fauna/fauna_antarctic_petrel.json
+++ b/database/fauna/fauna_antarctic_petrel.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 161
 }

--- a/database/fauna/fauna_antarctic_skua.json
+++ b/database/fauna/fauna_antarctic_skua.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 165
 }

--- a/database/fauna/fauna_ash_field_ground_beetle.json
+++ b/database/fauna/fauna_ash_field_ground_beetle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 155
 }

--- a/database/fauna/fauna_ash_glider_squirrel.json
+++ b/database/fauna/fauna_ash_glider_squirrel.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 71
 }

--- a/database/fauna/fauna_ash_plains_cricket.json
+++ b/database/fauna/fauna_ash_plains_cricket.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 173
 }

--- a/database/fauna/fauna_ash_skinned_courtesan.json
+++ b/database/fauna/fauna_ash_skinned_courtesan.json
@@ -16,5 +16,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 210
 }

--- a/database/fauna/fauna_ash_valley_field_mouse.json
+++ b/database/fauna/fauna_ash_valley_field_mouse.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 81
 }

--- a/database/fauna/fauna_ash_valley_scorpion.json
+++ b/database/fauna/fauna_ash_valley_scorpion.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 167
 }

--- a/database/fauna/fauna_asura_marked_black_ammonite.json
+++ b/database/fauna/fauna_asura_marked_black_ammonite.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 151
 }

--- a/database/fauna/fauna_asura_tainted_bat.json
+++ b/database/fauna/fauna_asura_tainted_bat.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 226
 }

--- a/database/fauna/fauna_asura_tainted_gargoyle.json
+++ b/database/fauna/fauna_asura_tainted_gargoyle.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 216
 }

--- a/database/fauna/fauna_asura_tainted_owl.json
+++ b/database/fauna/fauna_asura_tainted_owl.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 234
 }

--- a/database/fauna/fauna_banded_scavenger_voay.json
+++ b/database/fauna/fauna_banded_scavenger_voay.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 120
 }

--- a/database/fauna/fauna_basalt_armored_scavenger.json
+++ b/database/fauna/fauna_basalt_armored_scavenger.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 147
 }

--- a/database/fauna/fauna_basalt_cave_lurker.json
+++ b/database/fauna/fauna_basalt_cave_lurker.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 154
 }

--- a/database/fauna/fauna_basalt_cliff_hornbill.json
+++ b/database/fauna/fauna_basalt_cliff_hornbill.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 78
 }

--- a/database/fauna/fauna_baurusuchus.json
+++ b/database/fauna/fauna_baurusuchus.json
@@ -24,5 +24,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A heavy, quadrupedal land crocodile that prowls the delta, specializing in ambush techniques in shallow reed marshes.",
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 18
 }

--- a/database/fauna/fauna_bioluminescent_moss_dweller.json
+++ b/database/fauna/fauna_bioluminescent_moss_dweller.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 57
 }

--- a/database/fauna/fauna_black_barked_canopy_tendua.json
+++ b/database/fauna/fauna_black_barked_canopy_tendua.json
@@ -28,5 +28,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A melanistic, dark-coated subspecies of Tendua that hunts within the dense mangrove canopies of the Godavari delta.",
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 11
 }

--- a/database/fauna/fauna_black_striped_siege_bee.json
+++ b/database/fauna/fauna_black_striped_siege_bee.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 61
 }

--- a/database/fauna/fauna_boiling_water_hermit_crab.json
+++ b/database/fauna/fauna_boiling_water_hermit_crab.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 168
 }

--- a/database/fauna/fauna_bone_plated_orca.json
+++ b/database/fauna/fauna_bone_plated_orca.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 122
 }

--- a/database/fauna/fauna_burrowing_tortoise.json
+++ b/database/fauna/fauna_burrowing_tortoise.json
@@ -28,5 +28,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A large, long-lived tortoise (living 80-120 years) that digs spiral tunnels in a symbiotic relationship with the Nagaraptors, forming the underground foundations of the Taj Nest-Homes.",
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 13
 }

--- a/database/fauna/fauna_camelosuchus_calf.json
+++ b/database/fauna/fauna_camelosuchus_calf.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "playful"
+  "mood": "playful",
+  "source_index": 109
 }

--- a/database/fauna/fauna_clay_born_watcher.json
+++ b/database/fauna/fauna_clay_born_watcher.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 228
 }

--- a/database/fauna/fauna_cloud_antelope.json
+++ b/database/fauna/fauna_cloud_antelope.json
@@ -16,5 +16,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "mythic"
+  "mood": "mythic",
+  "source_index": 5
 }

--- a/database/fauna/fauna_cloud_cricket.json
+++ b/database/fauna/fauna_cloud_cricket.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 187
 }

--- a/database/fauna/fauna_cloud_leopard.json
+++ b/database/fauna/fauna_cloud_leopard.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 182
 }

--- a/database/fauna/fauna_cloud_lurking_gecko.json
+++ b/database/fauna/fauna_cloud_lurking_gecko.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 198
 }

--- a/database/fauna/fauna_cloud_squirrel.json
+++ b/database/fauna/fauna_cloud_squirrel.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "playful"
+  "mood": "playful",
+  "source_index": 195
 }

--- a/database/fauna/fauna_cloud_weaver_spider_gaganjala.json
+++ b/database/fauna/fauna_cloud_weaver_spider_gaganjala.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 177
 }

--- a/database/fauna/fauna_cloud_weaver_spiderling.json
+++ b/database/fauna/fauna_cloud_weaver_spiderling.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 203
 }

--- a/database/fauna/fauna_coastal_sand_sprinter.json
+++ b/database/fauna/fauna_coastal_sand_sprinter.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 92
 }

--- a/database/fauna/fauna_cognitavi_cloud_hermit.json
+++ b/database/fauna/fauna_cognitavi_cloud_hermit.json
@@ -13,5 +13,6 @@
     "docs/bestiary.md"
   ],
   "mood": "graceful",
-  "sentient": true
+  "sentient": true,
+  "source_index": 178
 }

--- a/database/fauna/fauna_colossal_void_devourer.json
+++ b/database/fauna/fauna_colossal_void_devourer.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 206
 }

--- a/database/fauna/fauna_copper_veined_snail.json
+++ b/database/fauna/fauna_copper_veined_snail.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 148
 }

--- a/database/fauna/fauna_coral_dwelling_moray.json
+++ b/database/fauna/fauna_coral_dwelling_moray.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 130
 }

--- a/database/fauna/fauna_crested_marsh_runner.json
+++ b/database/fauna/fauna_crested_marsh_runner.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 30
 }

--- a/database/fauna/fauna_crested_sylvian.json
+++ b/database/fauna/fauna_crested_sylvian.json
@@ -15,5 +15,6 @@
     "docs/bestiary.md"
   ],
   "mood": "fearsome",
-  "sentient": true
+  "sentient": true,
+  "source_index": 116
 }

--- a/database/fauna/fauna_crimson_eyed_adder.json
+++ b/database/fauna/fauna_crimson_eyed_adder.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 95
 }

--- a/database/fauna/fauna_deep_river_bronze.json
+++ b/database/fauna/fauna_deep_river_bronze.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 9
 }

--- a/database/fauna/fauna_delta_fiddler_crab.json
+++ b/database/fauna/fauna_delta_fiddler_crab.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 45
 }

--- a/database/fauna/fauna_delta_kingfisher.json
+++ b/database/fauna/fauna_delta_kingfisher.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 27
 }

--- a/database/fauna/fauna_delta_reed_python.json
+++ b/database/fauna/fauna_delta_reed_python.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 37
 }

--- a/database/fauna/fauna_desert_falcon.json
+++ b/database/fauna/fauna_desert_falcon.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 101
 }

--- a/database/fauna/fauna_desert_horned_owl.json
+++ b/database/fauna/fauna_desert_horned_owl.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 110
 }

--- a/database/fauna/fauna_desert_jerboa_rat.json
+++ b/database/fauna/fauna_desert_jerboa_rat.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 96
 }

--- a/database/fauna/fauna_dimetrodon_scout_mount.json
+++ b/database/fauna/fauna_dimetrodon_scout_mount.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 232
 }

--- a/database/fauna/fauna_dimetrodon_war_mount.json
+++ b/database/fauna/fauna_dimetrodon_war_mount.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 221
 }

--- a/database/fauna/fauna_dune_lurking_scorpion.json
+++ b/database/fauna/fauna_dune_lurking_scorpion.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 100
 }

--- a/database/fauna/fauna_dune_lurking_spider.json
+++ b/database/fauna/fauna_dune_lurking_spider.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 112
 }

--- a/database/fauna/fauna_dune_running_lizard.json
+++ b/database/fauna/fauna_dune_running_lizard.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 108
 }

--- a/database/fauna/fauna_ember_born_dancer.json
+++ b/database/fauna/fauna_ember_born_dancer.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 215
 }

--- a/database/fauna/fauna_ember_scattering_sprite.json
+++ b/database/fauna/fauna_ember_scattering_sprite.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 229
 }

--- a/database/fauna/fauna_estemmenosuchus_executioner.json
+++ b/database/fauna/fauna_estemmenosuchus_executioner.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 222
 }

--- a/database/fauna/fauna_estuary_archer_fish.json
+++ b/database/fauna/fauna_estuary_archer_fish.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 44
 }

--- a/database/fauna/fauna_feral_harappan_night_stalker.json
+++ b/database/fauna/fauna_feral_harappan_night_stalker.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 211
 }

--- a/database/fauna/fauna_floating_island_chameleon.json
+++ b/database/fauna/fauna_floating_island_chameleon.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 192
 }

--- a/database/fauna/fauna_floating_island_shrew.json
+++ b/database/fauna/fauna_floating_island_shrew.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 180
 }

--- a/database/fauna/fauna_flying_fish_of_the_tethys.json
+++ b/database/fauna/fauna_flying_fish_of_the_tethys.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 131
 }

--- a/database/fauna/fauna_frost_whisker_carp.json
+++ b/database/fauna/fauna_frost_whisker_carp.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 152
 }

--- a/database/fauna/fauna_gargoyle_bat.json
+++ b/database/fauna/fauna_gargoyle_bat.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 190
 }

--- a/database/fauna/fauna_garudasaur_eagle.json
+++ b/database/fauna/fauna_garudasaur_eagle.json
@@ -25,5 +25,6 @@
   "placement": "encounter",
   "rarity": "mythic",
   "journal_prompt": "A colossal mountain eagle with obsidian-tipped feathers, carrying small goats and primates to its nest on the high volcanic ledges.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 67
 }

--- a/database/fauna/fauna_gedrosian_desert_fox.json
+++ b/database/fauna/fauna_gedrosian_desert_fox.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 107
 }

--- a/database/fauna/fauna_gedrosian_desert_wolf.json
+++ b/database/fauna/fauna_gedrosian_desert_wolf.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 111
 }

--- a/database/fauna/fauna_gedrosian_sand_grouse.json
+++ b/database/fauna/fauna_gedrosian_sand_grouse.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 114
 }

--- a/database/fauna/fauna_gedrosian_spiny_lizard.json
+++ b/database/fauna/fauna_gedrosian_spiny_lizard.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 98
 }

--- a/database/fauna/fauna_gedrosian_spiny_tailed_lizard.json
+++ b/database/fauna/fauna_gedrosian_spiny_tailed_lizard.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 50
 }

--- a/database/fauna/fauna_giant_blue_ringed_octopus.json
+++ b/database/fauna/fauna_giant_blue_ringed_octopus.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 127
 }

--- a/database/fauna/fauna_giant_horned_voay.json
+++ b/database/fauna/fauna_giant_horned_voay.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 119
 }

--- a/database/fauna/fauna_giant_jungle_raptor.json
+++ b/database/fauna/fauna_giant_jungle_raptor.json
@@ -15,5 +15,6 @@
     "docs/bestiary.md"
   ],
   "mood": "fearsome",
-  "sentient": true
+  "sentient": true,
+  "source_index": 118
 }

--- a/database/fauna/fauna_giant_riding_ostrich.json
+++ b/database/fauna/fauna_giant_riding_ostrich.json
@@ -25,5 +25,6 @@
   "placement": "encounter",
   "rarity": "rare",
   "journal_prompt": "A massive, flightless bird trained by the Tushara nomads to carry heavy cargo and scouts across the arid frontiers.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 90
 }

--- a/database/fauna/fauna_giant_steel_shelled_snail.json
+++ b/database/fauna/fauna_giant_steel_shelled_snail.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 149
 }

--- a/database/fauna/fauna_glacial_ice_flea.json
+++ b/database/fauna/fauna_glacial_ice_flea.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 170
 }

--- a/database/fauna/fauna_glacial_ribbon_seal.json
+++ b/database/fauna/fauna_glacial_ribbon_seal.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 174
 }

--- a/database/fauna/fauna_glacial_snow_hare.json
+++ b/database/fauna/fauna_glacial_snow_hare.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 158
 }

--- a/database/fauna/fauna_glacial_wolf_spider.json
+++ b/database/fauna/fauna_glacial_wolf_spider.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 164
 }

--- a/database/fauna/fauna_glacier_edged_seal.json
+++ b/database/fauna/fauna_glacier_edged_seal.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 159
 }

--- a/database/fauna/fauna_glass_scaled_viper.json
+++ b/database/fauna/fauna_glass_scaled_viper.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 94
 }

--- a/database/fauna/fauna_golden_honey_goliath.json
+++ b/database/fauna/fauna_golden_honey_goliath.json
@@ -24,5 +24,6 @@
   "placement": "encounter",
   "rarity": "mythic",
   "journal_prompt": "A colossal bee species of the Narmada cliffs, harvested for its essential-oil-rich medicinal honey. They are used as weapons in local siege engines.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 60
 }

--- a/database/fauna/fauna_golden_plumed_racer.json
+++ b/database/fauna/fauna_golden_plumed_racer.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 91
 }

--- a/database/fauna/fauna_gondwana_spice_sifter.json
+++ b/database/fauna/fauna_gondwana_spice_sifter.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 63
 }

--- a/database/fauna/fauna_gorgonopsid_pack_leader.json
+++ b/database/fauna/fauna_gorgonopsid_pack_leader.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 231
 }

--- a/database/fauna/fauna_gorgonopsid_war_beast.json
+++ b/database/fauna/fauna_gorgonopsid_war_beast.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 220
 }

--- a/database/fauna/fauna_grey_bark_mimic.json
+++ b/database/fauna/fauna_grey_bark_mimic.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 56
 }

--- a/database/fauna/fauna_hammerhead_reef_shark.json
+++ b/database/fauna/fauna_hammerhead_reef_shark.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 132
 }

--- a/database/fauna/fauna_high_altitude_falcon.json
+++ b/database/fauna/fauna_high_altitude_falcon.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 204
 }

--- a/database/fauna/fauna_highland_desert_beetle.json
+++ b/database/fauna/fauna_highland_desert_beetle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 115
 }

--- a/database/fauna/fauna_highland_ibex.json
+++ b/database/fauna/fauna_highland_ibex.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 103
 }

--- a/database/fauna/fauna_highland_rock_runner.json
+++ b/database/fauna/fauna_highland_rock_runner.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 93
 }

--- a/database/fauna/fauna_hill_macaque.json
+++ b/database/fauna/fauna_hill_macaque.json
@@ -16,5 +16,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "curious"
+  "mood": "curious",
+  "source_index": 3
 }

--- a/database/fauna/fauna_hourglass_centipede.json
+++ b/database/fauna/fauna_hourglass_centipede.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 105
 }

--- a/database/fauna/fauna_indus_unicorn.json
+++ b/database/fauna/fauna_indus_unicorn.json
@@ -25,5 +25,6 @@
   "placement": "encounter",
   "rarity": "mythic",
   "journal_prompt": "A legendary, swift-footed single-horned ungulate of the river valleys, highly revered and historically sacrificed in dark portals.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 21
 }

--- a/database/fauna/fauna_iridescent_lothal_silvanus.json
+++ b/database/fauna/fauna_iridescent_lothal_silvanus.json
@@ -15,5 +15,6 @@
     "docs/bestiary.md"
   ],
   "mood": "luminous",
-  "sentient": true
+  "sentient": true,
+  "source_index": 17
 }

--- a/database/fauna/fauna_jungle_crested_mount.json
+++ b/database/fauna/fauna_jungle_crested_mount.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 124
 }

--- a/database/fauna/fauna_jungle_hornbill.json
+++ b/database/fauna/fauna_jungle_hornbill.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 138
 }

--- a/database/fauna/fauna_jungle_horned_toad.json
+++ b/database/fauna/fauna_jungle_horned_toad.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 144
 }

--- a/database/fauna/fauna_jungle_python.json
+++ b/database/fauna/fauna_jungle_python.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 134
 }

--- a/database/fauna/fauna_jungle_web_spinner.json
+++ b/database/fauna/fauna_jungle_web_spinner.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 52
 }

--- a/database/fauna/fauna_lava_basalt_centipede.json
+++ b/database/fauna/fauna_lava_basalt_centipede.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 166
 }

--- a/database/fauna/fauna_lava_ledge_gecko.json
+++ b/database/fauna/fauna_lava_ledge_gecko.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 68
 }

--- a/database/fauna/fauna_lava_pool_shrimp.json
+++ b/database/fauna/fauna_lava_pool_shrimp.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 163
 }

--- a/database/fauna/fauna_lava_pool_water_beetle.json
+++ b/database/fauna/fauna_lava_pool_water_beetle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 54
 }

--- a/database/fauna/fauna_lava_vent_tubeworm.json
+++ b/database/fauna/fauna_lava_vent_tubeworm.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 156
 }

--- a/database/fauna/fauna_lava_vent_tubeworm_asurica.json
+++ b/database/fauna/fauna_lava_vent_tubeworm_asurica.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 172
 }

--- a/database/fauna/fauna_lesser_ember_skink.json
+++ b/database/fauna/fauna_lesser_ember_skink.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 59
 }

--- a/database/fauna/fauna_lesser_whisper_fig_bird.json
+++ b/database/fauna/fauna_lesser_whisper_fig_bird.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 62
 }

--- a/database/fauna/fauna_lethal_cave_spectre.json
+++ b/database/fauna/fauna_lethal_cave_spectre.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 217
 }

--- a/database/fauna/fauna_lodestone_beetle.json
+++ b/database/fauna/fauna_lodestone_beetle.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 183
 }

--- a/database/fauna/fauna_lodestone_snail.json
+++ b/database/fauna/fauna_lodestone_snail.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 197
 }

--- a/database/fauna/fauna_lothal_dune_sprinter.json
+++ b/database/fauna/fauna_lothal_dune_sprinter.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "playful"
+  "mood": "playful",
+  "source_index": 46
 }

--- a/database/fauna/fauna_lothal_heron_raptor.json
+++ b/database/fauna/fauna_lothal_heron_raptor.json
@@ -16,5 +16,6 @@
     "docs/bestiary.md"
   ],
   "mood": "watchful",
-  "sentient": true
+  "sentient": true,
+  "source_index": 41
 }

--- a/database/fauna/fauna_lothal_marsh_lurker.json
+++ b/database/fauna/fauna_lothal_marsh_lurker.json
@@ -28,5 +28,6 @@
   "placement": "encounter",
   "rarity": "rare",
   "journal_prompt": "An 8-foot giant river salamander that has survived since the Pleistocene. It waits in the murky delta pools of Lothal to ambush passing prey.",
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 6
 }

--- a/database/fauna/fauna_lothal_mud_skipper.json
+++ b/database/fauna/fauna_lothal_mud_skipper.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 24
 }

--- a/database/fauna/fauna_lothal_sand_plover.json
+++ b/database/fauna/fauna_lothal_sand_plover.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 34
 }

--- a/database/fauna/fauna_lothal_shell_cracker.json
+++ b/database/fauna/fauna_lothal_shell_cracker.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 36
 }

--- a/database/fauna/fauna_lunar_reflection_wraith.json
+++ b/database/fauna/fauna_lunar_reflection_wraith.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 212
 }

--- a/database/fauna/fauna_magma_claw_crab.json
+++ b/database/fauna/fauna_magma_claw_crab.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 146
 }

--- a/database/fauna/fauna_mangrove_crab_eater.json
+++ b/database/fauna/fauna_mangrove_crab_eater.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 32
 }

--- a/database/fauna/fauna_mangrove_snapping_turtle.json
+++ b/database/fauna/fauna_mangrove_snapping_turtle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 42
 }

--- a/database/fauna/fauna_mappa_mundi_flying_lizard.json
+++ b/database/fauna/fauna_mappa_mundi_flying_lizard.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 139
 }

--- a/database/fauna/fauna_mappa_mundi_forest_cat.json
+++ b/database/fauna/fauna_mappa_mundi_forest_cat.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 136
 }

--- a/database/fauna/fauna_mappa_mundi_tree_frog.json
+++ b/database/fauna/fauna_mappa_mundi_tree_frog.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 133
 }

--- a/database/fauna/fauna_mappa_mundi_tree_snail.json
+++ b/database/fauna/fauna_mappa_mundi_tree_snail.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 142
 }

--- a/database/fauna/fauna_marsh_dwelling_terrapin.json
+++ b/database/fauna/fauna_marsh_dwelling_terrapin.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 25
 }

--- a/database/fauna/fauna_mist_lurking_bat.json
+++ b/database/fauna/fauna_mist_lurking_bat.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 189
 }

--- a/database/fauna/fauna_mist_valley_thrush.json
+++ b/database/fauna/fauna_mist_valley_thrush.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 200
 }

--- a/database/fauna/fauna_monsoon_crane.json
+++ b/database/fauna/fauna_monsoon_crane.json
@@ -16,5 +16,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 2
 }

--- a/database/fauna/fauna_mountain_forest_boar.json
+++ b/database/fauna/fauna_mountain_forest_boar.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 75
 }

--- a/database/fauna/fauna_mud_armored_ambusher.json
+++ b/database/fauna/fauna_mud_armored_ambusher.json
@@ -27,5 +27,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A baurusuchid that cakes itself in river mud, keeping its body temperature low and hiding from terrestrial prey.",
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 20
 }

--- a/database/fauna/fauna_muria_river_otter.json
+++ b/database/fauna/fauna_muria_river_otter.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 23
 }

--- a/database/fauna/fauna_naga_infiltrator.json
+++ b/database/fauna/fauna_naga_infiltrator.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 219
 }

--- a/database/fauna/fauna_naga_kin_sentry.json
+++ b/database/fauna/fauna_naga_kin_sentry.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 230
 }

--- a/database/fauna/fauna_nagaraptor.json
+++ b/database/fauna/fauna_nagaraptor.json
@@ -27,5 +27,6 @@
   "rarity": "common",
   "journal_prompt": "Feathered velociraptor clans that have formed a complex diapsid scale-based civilization, using earthworks and moats to defend their nests.",
   "mood": "clever",
-  "sentient": true
+  "sentient": true,
+  "source_index": 12
 }

--- a/database/fauna/fauna_narmada_cave_bear.json
+++ b/database/fauna/fauna_narmada_cave_bear.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 65
 }

--- a/database/fauna/fauna_narmada_cave_crab.json
+++ b/database/fauna/fauna_narmada_cave_crab.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 80
 }

--- a/database/fauna/fauna_narmada_honey_guide.json
+++ b/database/fauna/fauna_narmada_honey_guide.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "clever"
+  "mood": "clever",
+  "source_index": 77
 }

--- a/database/fauna/fauna_narmada_mud_eel.json
+++ b/database/fauna/fauna_narmada_mud_eel.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 49
 }

--- a/database/fauna/fauna_narmada_rock_python.json
+++ b/database/fauna/fauna_narmada_rock_python.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 70
 }

--- a/database/fauna/fauna_narmada_tree_shrew.json
+++ b/database/fauna/fauna_narmada_tree_shrew.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "playful"
+  "mood": "playful",
+  "source_index": 83
 }

--- a/database/fauna/fauna_obsidian_cliff_eagle.json
+++ b/database/fauna/fauna_obsidian_cliff_eagle.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 84
 }

--- a/database/fauna/fauna_obsidian_winged_serpent.json
+++ b/database/fauna/fauna_obsidian_winged_serpent.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 218
 }

--- a/database/fauna/fauna_painted_deer.json
+++ b/database/fauna/fauna_painted_deer.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "gentle"
+  "mood": "gentle",
+  "source_index": 1
 }

--- a/database/fauna/fauna_prana_absorbing_butterfly.json
+++ b/database/fauna/fauna_prana_absorbing_butterfly.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 205
 }

--- a/database/fauna/fauna_prana_feeder_finch.json
+++ b/database/fauna/fauna_prana_feeder_finch.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 194
 }

--- a/database/fauna/fauna_quarry_spawned_tendua.json
+++ b/database/fauna/fauna_quarry_spawned_tendua.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 209
 }

--- a/database/fauna/fauna_rajasaurus_ambush_drake.json
+++ b/database/fauna/fauna_rajasaurus_ambush_drake.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 224
 }

--- a/database/fauna/fauna_red_crested_woodpecker.json
+++ b/database/fauna/fauna_red_crested_woodpecker.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 72
 }

--- a/database/fauna/fauna_reef_dwelling_octopus.json
+++ b/database/fauna/fauna_reef_dwelling_octopus.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 141
 }

--- a/database/fauna/fauna_river_otter.json
+++ b/database/fauna/fauna_river_otter.json
@@ -26,5 +26,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A slick shape rolls through the shallows, leaving rings of silver water behind.",
-  "mood": "playful"
+  "mood": "playful",
+  "source_index": 0
 }

--- a/database/fauna/fauna_sacred_stepwell_koi.json
+++ b/database/fauna/fauna_sacred_stepwell_koi.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 8
 }

--- a/database/fauna/fauna_salt_flat_beetle.json
+++ b/database/fauna/fauna_salt_flat_beetle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 102
 }

--- a/database/fauna/fauna_salt_flat_cricket.json
+++ b/database/fauna/fauna_salt_flat_cricket.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 113
 }

--- a/database/fauna/fauna_saltwater_gator_turtle.json
+++ b/database/fauna/fauna_saltwater_gator_turtle.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 28
 }

--- a/database/fauna/fauna_sand_burrowing_toad.json
+++ b/database/fauna/fauna_sand_burrowing_toad.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 104
 }

--- a/database/fauna/fauna_sand_camouflage_beedu.json
+++ b/database/fauna/fauna_sand_camouflage_beedu.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 86
 }

--- a/database/fauna/fauna_sand_resurrected_behemoth.json
+++ b/database/fauna/fauna_sand_resurrected_behemoth.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 207
 }

--- a/database/fauna/fauna_saraswati_delta_heron.json
+++ b/database/fauna/fauna_saraswati_delta_heron.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 22
 }

--- a/database/fauna/fauna_saraswati_horned_frog.json
+++ b/database/fauna/fauna_saraswati_horned_frog.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 47
 }

--- a/database/fauna/fauna_saraswati_reed_warbler.json
+++ b/database/fauna/fauna_saraswati_reed_warbler.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "clever"
+  "mood": "clever",
+  "source_index": 29
 }

--- a/database/fauna/fauna_scutosaurus_battering_ram.json
+++ b/database/fauna/fauna_scutosaurus_battering_ram.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 233
 }

--- a/database/fauna/fauna_scutosaurus_shield_beast.json
+++ b/database/fauna/fauna_scutosaurus_shield_beast.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 223
 }

--- a/database/fauna/fauna_scythian_war_camel.json
+++ b/database/fauna/fauna_scythian_war_camel.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 99
 }

--- a/database/fauna/fauna_scythian_wild_ass.json
+++ b/database/fauna/fauna_scythian_wild_ass.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 51
 }

--- a/database/fauna/fauna_sea_scorpion_queen.json
+++ b/database/fauna/fauna_sea_scorpion_queen.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 125
 }

--- a/database/fauna/fauna_serene_brown_ammonite.json
+++ b/database/fauna/fauna_serene_brown_ammonite.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 150
 }

--- a/database/fauna/fauna_shambala_ice_pike.json
+++ b/database/fauna/fauna_shambala_ice_pike.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 153
 }

--- a/database/fauna/fauna_shambala_snow_partridge.json
+++ b/database/fauna/fauna_shambala_snow_partridge.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 171
 }

--- a/database/fauna/fauna_shattered_sea_barracuda.json
+++ b/database/fauna/fauna_shattered_sea_barracuda.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 143
 }

--- a/database/fauna/fauna_shattered_sea_oyster.json
+++ b/database/fauna/fauna_shattered_sea_oyster.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "luminous"
+  "mood": "luminous",
+  "source_index": 129
 }

--- a/database/fauna/fauna_shell_turtle.json
+++ b/database/fauna/fauna_shell_turtle.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 4
 }

--- a/database/fauna/fauna_shilajit_guardian_lizard.json
+++ b/database/fauna/fauna_shilajit_guardian_lizard.json
@@ -24,5 +24,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A fire-spitting cliff lizard that ingests raw sulfur and flint to strike defensive sparks, guarding natural mineral deposits.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 58
 }

--- a/database/fauna/fauna_silver_banded_sea_snake.json
+++ b/database/fauna/fauna_silver_banded_sea_snake.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 39
 }

--- a/database/fauna/fauna_sky_dragon_fly.json
+++ b/database/fauna/fauna_sky_dragon_fly.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 193
 }

--- a/database/fauna/fauna_sky_faring_crab.json
+++ b/database/fauna/fauna_sky_faring_crab.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 202
 }

--- a/database/fauna/fauna_sky_faring_grasshopper.json
+++ b/database/fauna/fauna_sky_faring_grasshopper.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 55
 }

--- a/database/fauna/fauna_sky_faring_jellyfish.json
+++ b/database/fauna/fauna_sky_faring_jellyfish.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 196
 }

--- a/database/fauna/fauna_sky_faring_orca.json
+++ b/database/fauna/fauna_sky_faring_orca.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 179
 }

--- a/database/fauna/fauna_sky_faring_otter.json
+++ b/database/fauna/fauna_sky_faring_otter.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 199
 }

--- a/database/fauna/fauna_sky_gull.json
+++ b/database/fauna/fauna_sky_gull.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 181
 }

--- a/database/fauna/fauna_sky_snake.json
+++ b/database/fauna/fauna_sky_snake.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 188
 }

--- a/database/fauna/fauna_sky_turtle.json
+++ b/database/fauna/fauna_sky_turtle.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "graceful"
+  "mood": "graceful",
+  "source_index": 185
 }

--- a/database/fauna/fauna_sleek_dromedary_croc.json
+++ b/database/fauna/fauna_sleek_dromedary_croc.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 89
 }

--- a/database/fauna/fauna_soot_furred_rat.json
+++ b/database/fauna/fauna_soot_furred_rat.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 157
 }

--- a/database/fauna/fauna_soot_winged_falcon.json
+++ b/database/fauna/fauna_soot_winged_falcon.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 162
 }

--- a/database/fauna/fauna_sooty_shearwater.json
+++ b/database/fauna/fauna_sooty_shearwater.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 169
 }

--- a/database/fauna/fauna_southern_reef_stingray.json
+++ b/database/fauna/fauna_southern_reef_stingray.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 145
 }

--- a/database/fauna/fauna_southern_sea_eagle.json
+++ b/database/fauna/fauna_southern_sea_eagle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 135
 }

--- a/database/fauna/fauna_southern_sea_turtle.json
+++ b/database/fauna/fauna_southern_sea_turtle.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 137
 }

--- a/database/fauna/fauna_spotted_marsh_tendua.json
+++ b/database/fauna/fauna_spotted_marsh_tendua.json
@@ -28,5 +28,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A highly intelligent, leopard-like feline of the wetlands that has evolved human-like eye placement and ocular mimicry to stalk its prey.",
-  "mood": "clever"
+  "mood": "clever",
+  "source_index": 10
 }

--- a/database/fauna/fauna_static_charged_wasp.json
+++ b/database/fauna/fauna_static_charged_wasp.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 184
 }

--- a/database/fauna/fauna_stealth_patterned_theropod.json
+++ b/database/fauna/fauna_stealth_patterned_theropod.json
@@ -15,5 +15,6 @@
     "docs/bestiary.md"
   ],
   "mood": "fearsome",
-  "sentient": true
+  "sentient": true,
+  "source_index": 117
 }

--- a/database/fauna/fauna_steppe_plumed_elephantbird.json
+++ b/database/fauna/fauna_steppe_plumed_elephantbird.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 123
 }

--- a/database/fauna/fauna_stepwell_shadow.json
+++ b/database/fauna/fauna_stepwell_shadow.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 213
 }

--- a/database/fauna/fauna_striped_reed_stalker.json
+++ b/database/fauna/fauna_striped_reed_stalker.json
@@ -27,5 +27,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A camouflaged subspecies of Baurusuchus with vertical stripes, blending into the marsh grass of the Saraswati delta.",
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 19
 }

--- a/database/fauna/fauna_swamp_wallaby.json
+++ b/database/fauna/fauna_swamp_wallaby.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 35
 }

--- a/database/fauna/fauna_taklamakan_sand_cat.json
+++ b/database/fauna/fauna_taklamakan_sand_cat.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 97
 }

--- a/database/fauna/fauna_taklamakan_sand_viper.json
+++ b/database/fauna/fauna_taklamakan_sand_viper.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 106
 }

--- a/database/fauna/fauna_tethyan_blue_crayfish.json
+++ b/database/fauna/fauna_tethyan_blue_crayfish.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 26
 }

--- a/database/fauna/fauna_tethyan_blue_fin_tuna.json
+++ b/database/fauna/fauna_tethyan_blue_fin_tuna.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 140
 }

--- a/database/fauna/fauna_tethyan_flying_squid.json
+++ b/database/fauna/fauna_tethyan_flying_squid.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 53
 }

--- a/database/fauna/fauna_tethyan_mud_snipe.json
+++ b/database/fauna/fauna_tethyan_mud_snipe.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 38
 }

--- a/database/fauna/fauna_tethyan_reef_lurker.json
+++ b/database/fauna/fauna_tethyan_reef_lurker.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 126
 }

--- a/database/fauna/fauna_tethys_leviathan_calf.json
+++ b/database/fauna/fauna_tethys_leviathan_calf.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "playful"
+  "mood": "playful",
+  "source_index": 128
 }

--- a/database/fauna/fauna_tethys_pelican.json
+++ b/database/fauna/fauna_tethys_pelican.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 43
 }

--- a/database/fauna/fauna_tethys_river_dolphin.json
+++ b/database/fauna/fauna_tethys_river_dolphin.json
@@ -24,5 +24,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A pale, blind cetacean that navigates the muddy delta waters using sophisticated acoustic clicks, hunted by Kias for meat and skin.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 31
 }

--- a/database/fauna/fauna_underworld_blood_leech.json
+++ b/database/fauna/fauna_underworld_blood_leech.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 225
 }

--- a/database/fauna/fauna_underworld_water_snake.json
+++ b/database/fauna/fauna_underworld_water_snake.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 227
 }

--- a/database/fauna/fauna_vajraptor.json
+++ b/database/fauna/fauna_vajraptor.json
@@ -27,5 +27,6 @@
   "rarity": "common",
   "journal_prompt": "An intelligent, social, and territorial theropod bird with colorful plumage and excellent problem-solving skills, building hidden canopy nests.",
   "mood": "clever",
-  "sentient": true
+  "sentient": true,
+  "source_index": 14
 }

--- a/database/fauna/fauna_vanga_marsh_cat.json
+++ b/database/fauna/fauna_vanga_marsh_cat.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 40
 }

--- a/database/fauna/fauna_vanga_pearl_guide.json
+++ b/database/fauna/fauna_vanga_pearl_guide.json
@@ -30,5 +30,6 @@
   "rarity": "rare",
   "journal_prompt": "An elite subspecies of the hyper-intelligent Cognitavi navigator birds that aids Tuli seafarers in locating deep-sea oyster beds.",
   "mood": "clever",
-  "sentient": true
+  "sentient": true,
+  "source_index": 15
 }

--- a/database/fauna/fauna_vengi_marsh_harrier.json
+++ b/database/fauna/fauna_vengi_marsh_harrier.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 33
 }

--- a/database/fauna/fauna_venomous_vengi_mud_salamander.json
+++ b/database/fauna/fauna_venomous_vengi_mud_salamander.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 7
 }

--- a/database/fauna/fauna_vindhya_bark_gecko.json
+++ b/database/fauna/fauna_vindhya_bark_gecko.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "patient"
+  "mood": "patient",
+  "source_index": 79
 }

--- a/database/fauna/fauna_vindhya_centipede_eater.json
+++ b/database/fauna/fauna_vindhya_centipede_eater.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 82
 }

--- a/database/fauna/fauna_vindhya_cliff_goat.json
+++ b/database/fauna/fauna_vindhya_cliff_goat.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 64
 }

--- a/database/fauna/fauna_vindhya_forest_falcon.json
+++ b/database/fauna/fauna_vindhya_forest_falcon.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 48
 }

--- a/database/fauna/fauna_vindhya_hill_parakeet.json
+++ b/database/fauna/fauna_vindhya_hill_parakeet.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 85
 }

--- a/database/fauna/fauna_vindhya_horned_owl.json
+++ b/database/fauna/fauna_vindhya_horned_owl.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 69
 }

--- a/database/fauna/fauna_vindhya_langur.json
+++ b/database/fauna/fauna_vindhya_langur.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 73
 }

--- a/database/fauna/fauna_vindhya_leopard.json
+++ b/database/fauna/fauna_vindhya_leopard.json
@@ -15,5 +15,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 66
 }

--- a/database/fauna/fauna_vindhya_rock_squirrel.json
+++ b/database/fauna/fauna_vindhya_rock_squirrel.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 76
 }

--- a/database/fauna/fauna_void_born_leech.json
+++ b/database/fauna/fauna_void_born_leech.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 235
 }

--- a/database/fauna/fauna_volcanic_ash_moth.json
+++ b/database/fauna/fauna_volcanic_ash_moth.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 175
 }

--- a/database/fauna/fauna_volcanic_salamander.json
+++ b/database/fauna/fauna_volcanic_salamander.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 160
 }

--- a/database/fauna/fauna_volcanic_shrew.json
+++ b/database/fauna/fauna_volcanic_shrew.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 74
 }

--- a/database/fauna/fauna_white_ash_bride.json
+++ b/database/fauna/fauna_white_ash_bride.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 214
 }

--- a/database/fauna/fauna_white_salt_flat_ray.json
+++ b/database/fauna/fauna_white_salt_flat_ray.json
@@ -14,5 +14,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "fearsome"
+  "mood": "fearsome",
+  "source_index": 87
 }

--- a/database/fauna/fauna_winged_behemoth_manticore.json
+++ b/database/fauna/fauna_winged_behemoth_manticore.json
@@ -12,5 +12,6 @@
   "sources": [
     "docs/bestiary.md"
   ],
-  "mood": "uncanny"
+  "mood": "uncanny",
+  "source_index": 208
 }

--- a/database/fauna/fauna_woolly_bactrian_croc.json
+++ b/database/fauna/fauna_woolly_bactrian_croc.json
@@ -24,5 +24,6 @@
   "placement": "encounter",
   "rarity": "common",
   "journal_prompt": "A heavy, rugged crocodile-mammal hybrid with two water-retention humps, used by northern nomads to cross the highland deserts.",
-  "mood": "watchful"
+  "mood": "watchful",
+  "source_index": 88
 }

--- a/database/flora/flora_aero_mangrove_vayu_vriksha.json
+++ b/database/flora/flora_aero_mangrove_vayu_vriksha.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 50
 }

--- a/database/flora/flora_antarctic_kelp_grass.json
+++ b/database/flora/flora_antarctic_kelp_grass.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 48
 }

--- a/database/flora/flora_asura_tainted_flesh_vine.json
+++ b/database/flora/flora_asura_tainted_flesh_vine.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 64
 }

--- a/database/flora/flora_bitter_black_barley.json
+++ b/database/flora/flora_bitter_black_barley.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 23
 }

--- a/database/flora/flora_bitter_marsh_root.json
+++ b/database/flora/flora_bitter_marsh_root.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 5
 }

--- a/database/flora/flora_black_ash_tea.json
+++ b/database/flora/flora_black_ash_tea.json
@@ -22,5 +22,6 @@
   ],
   "placement": "flavour",
   "rarity": "common",
-  "journal_prompt": "Hardy wild tea bushes adapted to highly acidic, sulfur-rich volcanic soils, producing dark, highly caffeinated leaves."
+  "journal_prompt": "Hardy wild tea bushes adapted to highly acidic, sulfur-rich volcanic soils, producing dark, highly caffeinated leaves.",
+  "source_index": 12
 }

--- a/database/flora/flora_blood_red_asura_lotus.json
+++ b/database/flora/flora_blood_red_asura_lotus.json
@@ -21,5 +21,6 @@
   ],
   "placement": "flavour",
   "rarity": "common",
-  "journal_prompt": "An invasive, deep-crimson lotus that thrives in areas of past magical corruption, its pollen inducing vivid, restless dreams."
+  "journal_prompt": "An invasive, deep-crimson lotus that thrives in areas of past magical corruption, its pollen inducing vivid, restless dreams.",
+  "source_index": 3
 }

--- a/database/flora/flora_blue_healing_turmeric.json
+++ b/database/flora/flora_blue_healing_turmeric.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 21
 }

--- a/database/flora/flora_blue_pulse_root.json
+++ b/database/flora/flora_blue_pulse_root.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 53
 }

--- a/database/flora/flora_blue_scholar_s_moss.json
+++ b/database/flora/flora_blue_scholar_s_moss.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 10
 }

--- a/database/flora/flora_bonewood_mangrove.json
+++ b/database/flora/flora_bonewood_mangrove.json
@@ -25,5 +25,6 @@
   ],
   "placement": "flavour",
   "rarity": "common",
-  "journal_prompt": "Mangrove trees that absorb calcium and basalt from the volcanic coast, yielding a naturally curved, bone-hard timber used for construction."
+  "journal_prompt": "Mangrove trees that absorb calcium and basalt from the volcanic coast, yielding a naturally curved, bone-hard timber used for construction.",
+  "source_index": 6
 }

--- a/database/flora/flora_cloud_weaver_vine.json
+++ b/database/flora/flora_cloud_weaver_vine.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 58
 }

--- a/database/flora/flora_crimson_blood_weed.json
+++ b/database/flora/flora_crimson_blood_weed.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 62
 }

--- a/database/flora/flora_crimson_leaved_ash_banyan.json
+++ b/database/flora/flora_crimson_leaved_ash_banyan.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 40
 }

--- a/database/flora/flora_crimson_spice_root.json
+++ b/database/flora/flora_crimson_spice_root.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 20
 }

--- a/database/flora/flora_cursed_ash_fern.json
+++ b/database/flora/flora_cursed_ash_fern.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 66
 }

--- a/database/flora/flora_deep_earth_obsidian_lotus.json
+++ b/database/flora/flora_deep_earth_obsidian_lotus.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 43
 }

--- a/database/flora/flora_desert_saltbush.json
+++ b/database/flora/flora_desert_saltbush.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 25
 }

--- a/database/flora/flora_emerald_harbor_lotus.json
+++ b/database/flora/flora_emerald_harbor_lotus.json
@@ -23,5 +23,6 @@
   ],
   "placement": "flavour",
   "rarity": "rare",
-  "journal_prompt": "A massive aquatic lotus with bright green petals that blooms in the estuaries of Lothal, drawing mineral-rich runoff."
+  "journal_prompt": "A massive aquatic lotus with bright green petals that blooms in the estuaries of Lothal, drawing mineral-rich runoff.",
+  "source_index": 2
 }

--- a/database/flora/flora_fever_root.json
+++ b/database/flora/flora_fever_root.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 65
 }

--- a/database/flora/flora_giant_bird_nest_fern.json
+++ b/database/flora/flora_giant_bird_nest_fern.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 34
 }

--- a/database/flora/flora_giant_mangrove_palm.json
+++ b/database/flora/flora_giant_mangrove_palm.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 37
 }

--- a/database/flora/flora_glacial_lichen.json
+++ b/database/flora/flora_glacial_lichen.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 46
 }

--- a/database/flora/flora_golden_amber_lotus.json
+++ b/database/flora/flora_golden_amber_lotus.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 42
 }

--- a/database/flora/flora_golden_ember_leaf.json
+++ b/database/flora/flora_golden_ember_leaf.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 13
 }

--- a/database/flora/flora_golden_sun_barley.json
+++ b/database/flora/flora_golden_sun_barley.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 22
 }

--- a/database/flora/flora_hanging_monkey_pitcher.json
+++ b/database/flora/flora_hanging_monkey_pitcher.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 33
 }

--- a/database/flora/flora_healing_silver_root.json
+++ b/database/flora/flora_healing_silver_root.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 4
 }

--- a/database/flora/flora_highland_bitter_mahua.json
+++ b/database/flora/flora_highland_bitter_mahua.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 17
 }

--- a/database/flora/flora_hourglass_cactus.json
+++ b/database/flora/flora_hourglass_cactus.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 26
 }

--- a/database/flora/flora_iron_root_mangrove.json
+++ b/database/flora/flora_iron_root_mangrove.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 8
 }

--- a/database/flora/flora_ivory_coastal_bonewood.json
+++ b/database/flora/flora_ivory_coastal_bonewood.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 7
 }

--- a/database/flora/flora_jungle_crested_bamboo.json
+++ b/database/flora/flora_jungle_crested_bamboo.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 32
 }

--- a/database/flora/flora_lapis_lazuli_reef_builder.json
+++ b/database/flora/flora_lapis_lazuli_reef_builder.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 31
 }

--- a/database/flora/flora_lava_glass_fern.json
+++ b/database/flora/flora_lava_glass_fern.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 45
 }

--- a/database/flora/flora_lesser_whisper_fig.json
+++ b/database/flora/flora_lesser_whisper_fig.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 15
 }

--- a/database/flora/flora_levitation_gourd_sky_balloon.json
+++ b/database/flora/flora_levitation_gourd_sky_balloon.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 51
 }

--- a/database/flora/flora_lodestone_moss.json
+++ b/database/flora/flora_lodestone_moss.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 59
 }

--- a/database/flora/flora_mappa_mundi_banyan.json
+++ b/database/flora/flora_mappa_mundi_banyan.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 39
 }

--- a/database/flora/flora_moon_reflecting_mint.json
+++ b/database/flora/flora_moon_reflecting_mint.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 56
 }

--- a/database/flora/flora_naraka_pitcher_plant.json
+++ b/database/flora/flora_naraka_pitcher_plant.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 69
 }

--- a/database/flora/flora_oasis_date_palm.json
+++ b/database/flora/flora_oasis_date_palm.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 29
 }

--- a/database/flora/flora_obsidian_rose.json
+++ b/database/flora/flora_obsidian_rose.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 68
 }

--- a/database/flora/flora_plunging_fire_siege_tree.json
+++ b/database/flora/flora_plunging_fire_siege_tree.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 60
 }

--- a/database/flora/flora_poison_barb_indigo.json
+++ b/database/flora/flora_poison_barb_indigo.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 1
 }

--- a/database/flora/flora_prana_lotus.json
+++ b/database/flora/flora_prana_lotus.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 57
 }

--- a/database/flora/flora_red_blood_coral.json
+++ b/database/flora/flora_red_blood_coral.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 30
 }

--- a/database/flora/flora_root_anchored_artillery_tree.json
+++ b/database/flora/flora_root_anchored_artillery_tree.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 61
 }

--- a/database/flora/flora_sand_dune_gourd.json
+++ b/database/flora/flora_sand_dune_gourd.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 24
 }

--- a/database/flora/flora_saraswati_reed.json
+++ b/database/flora/flora_saraswati_reed.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 9
 }

--- a/database/flora/flora_shattered_sea_kelp.json
+++ b/database/flora/flora_shattered_sea_kelp.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 35
 }

--- a/database/flora/flora_shattered_seaweed_silk.json
+++ b/database/flora/flora_shattered_seaweed_silk.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 38
 }

--- a/database/flora/flora_shilajit_creeper.json
+++ b/database/flora/flora_shilajit_creeper.json
@@ -23,5 +23,6 @@
   ],
   "placement": "flavour",
   "rarity": "common",
-  "journal_prompt": "A trailing, primitive moss-like plant that grows near mineral fissures, absorbing pure bitumen and organic compounds from the rock."
+  "journal_prompt": "A trailing, primitive moss-like plant that grows near mineral fissures, absorbing pure bitumen and organic compounds from the rock.",
+  "source_index": 18
 }

--- a/database/flora/flora_silver_leaved_oracle_fig.json
+++ b/database/flora/flora_silver_leaved_oracle_fig.json
@@ -23,5 +23,6 @@
   ],
   "placement": "flavour",
   "rarity": "rare",
-  "journal_prompt": "A massive fig tree grown from a magical moon-seed, its roots acting as a biological archive tree whispering memories in the wind."
+  "journal_prompt": "A massive fig tree grown from a magical moon-seed, its roots acting as a biological archive tree whispering memories in the wind.",
+  "source_index": 14
 }

--- a/database/flora/flora_snow_looming_moss.json
+++ b/database/flora/flora_snow_looming_moss.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 47
 }

--- a/database/flora/flora_soot_grass.json
+++ b/database/flora/flora_soot_grass.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 44
 }

--- a/database/flora/flora_spiny_acacia.json
+++ b/database/flora/flora_spiny_acacia.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 27
 }

--- a/database/flora/flora_static_charged_bramble.json
+++ b/database/flora/flora_static_charged_bramble.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 52
 }

--- a/database/flora/flora_sun_catcher_herb.json
+++ b/database/flora/flora_sun_catcher_herb.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 55
 }

--- a/database/flora/flora_sweet_indigo.json
+++ b/database/flora/flora_sweet_indigo.json
@@ -23,5 +23,6 @@
   ],
   "placement": "flavour",
   "rarity": "common",
-  "journal_prompt": "A domesticated decorative vine bred by Harappan settlers, boasting vibrant purple flowers that yield a sweet-scented blue dye."
+  "journal_prompt": "A domesticated decorative vine bred by Harappan settlers, boasting vibrant purple flowers that yield a sweet-scented blue dye.",
+  "source_index": 0
 }

--- a/database/flora/flora_sweet_nectar_mahua.json
+++ b/database/flora/flora_sweet_nectar_mahua.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 16
 }

--- a/database/flora/flora_tawny_sagebrush.json
+++ b/database/flora/flora_tawny_sagebrush.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 28
 }

--- a/database/flora/flora_toxic_crimson_root.json
+++ b/database/flora/flora_toxic_crimson_root.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 54
 }

--- a/database/flora/flora_toxic_red_spore_moss.json
+++ b/database/flora/flora_toxic_red_spore_moss.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 11
 }

--- a/database/flora/flora_vindhya_pine.json
+++ b/database/flora/flora_vindhya_pine.json
@@ -14,5 +14,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 19
 }

--- a/database/flora/flora_violet_strangler_vine.json
+++ b/database/flora/flora_violet_strangler_vine.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 63
 }

--- a/database/flora/flora_volcanic_beach_creeper.json
+++ b/database/flora/flora_volcanic_beach_creeper.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 36
 }

--- a/database/flora/flora_volcanic_sulfur_flower.json
+++ b/database/flora/flora_volcanic_sulfur_flower.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 49
 }

--- a/database/flora/flora_weeping_charcoal_tree.json
+++ b/database/flora/flora_weeping_charcoal_tree.json
@@ -13,5 +13,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 41
 }

--- a/database/flora/flora_whispering_blood_orchid.json
+++ b/database/flora/flora_whispering_blood_orchid.json
@@ -11,5 +11,6 @@
   "canon": "primary",
   "sources": [
     "docs/bestiary.md"
-  ]
+  ],
+  "source_index": 67
 }

--- a/database/schemas/fauna.schema.json
+++ b/database/schemas/fauna.schema.json
@@ -2,21 +2,73 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Fauna",
   "type": "object",
-  "required": ["id", "type", "name"],
+  "required": [
+    "id",
+    "type",
+    "name"
+  ],
   "properties": {
-    "id": { "type": "string", "pattern": "^fauna_[a-z0-9_]+$" },
-    "type": { "const": "fauna" },
-    "name": { "type": "string" },
-    "scientific": { "type": ["string", "null"] },
-    "taxonomy": { "type": "object" },
-    "diet": { "type": ["string", "null"] },
-    "habitats": { "type": "array", "items": { "type": "string" } },
-    "behaviour": { "type": "array", "items": { "type": "string" } },
-    "related_species": { "type": "array", "items": { "type": "string" } },
-    "notes": { "type": "string" },
-    "canon": { "type": "string", "enum": ["primary", "secondary", "draft"], "default": "primary" },
-    "sources": { "type": "array", "items": { "type": "string" } },
-
+    "id": {
+      "type": "string",
+      "pattern": "^fauna_[a-z0-9_]+$"
+    },
+    "type": {
+      "const": "fauna"
+    },
+    "name": {
+      "type": "string"
+    },
+    "scientific": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "taxonomy": {
+      "type": "object"
+    },
+    "diet": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "habitats": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "behaviour": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "related_species": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "string"
+    },
+    "canon": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "draft"
+      ],
+      "default": "primary"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "journal_prompt": {
       "type": "string",
       "description": "Player-facing prose read in the travel journal. Distinct from `notes`: `notes` is a reference fact for the canon reader, `journal_prompt` is the sentence the player sees. Exported as `journalPrompt`."
@@ -40,18 +92,53 @@
       "description": "Tile biomes this species may be placed in. Empty means it is never placed.",
       "items": {
         "type": "string",
-        "enum": ["sea", "coast", "plains", "forest", "wetland", "hills", "mountains", "desert", "river", "settlement", "landmark"]
+        "enum": [
+          "sea",
+          "coast",
+          "plains",
+          "forest",
+          "wetland",
+          "hills",
+          "mountains",
+          "desert",
+          "river",
+          "settlement",
+          "landmark"
+        ]
       }
     },
     "placement": {
       "type": "string",
-      "enum": ["encounter", "flavour", "lore"],
+      "enum": [
+        "encounter",
+        "flavour",
+        "lore"
+      ],
       "description": "`encounter` is met in play; `lore` is authored but never placed. Untagged imports default to `lore` so nothing reaches the encounter table unreviewed."
     },
-    "rarity": { "type": "string", "enum": ["common", "rare", "mythic"] },
+    "rarity": {
+      "type": "string",
+      "enum": [
+        "common",
+        "rare",
+        "mythic"
+      ]
+    },
     "mood": {
       "type": "string",
-      "enum": ["clever", "curious", "fearsome", "gentle", "graceful", "luminous", "mythic", "patient", "playful", "uncanny", "watchful"],
+      "enum": [
+        "clever",
+        "curious",
+        "fearsome",
+        "gentle",
+        "graceful",
+        "luminous",
+        "mythic",
+        "patient",
+        "playful",
+        "uncanny",
+        "watchful"
+      ],
       "description": "Drives journal tone. Fauna only."
     },
     "sentient": {
@@ -61,8 +148,15 @@
     },
     "epochs": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Epoch ids from database/timeline/epochs.json. Absent means present in all epochs."
+    },
+    "source_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Position in the authored bestiary sequence (prototype starters first for fauna). Array order decides which species pickFor lands on for a tile, so this is part of the seed contract, not presentation."
     }
   },
   "additionalProperties": true

--- a/database/schemas/flora.schema.json
+++ b/database/schemas/flora.schema.json
@@ -2,20 +2,67 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Flora",
   "type": "object",
-  "required": ["id", "type", "name"],
+  "required": [
+    "id",
+    "type",
+    "name"
+  ],
   "properties": {
-    "id": { "type": "string", "pattern": "^flora_[a-z0-9_]+$" },
-    "type": { "const": "flora" },
-    "name": { "type": "string" },
-    "scientific": { "type": ["string", "null"] },
-    "taxonomy": { "type": "object" },
-    "habitats": { "type": "array", "items": { "type": "string" } },
-    "uses": { "type": "array", "items": { "type": "string" } },
-    "related_species": { "type": "array", "items": { "type": "string" } },
-    "notes": { "type": "string" },
-    "canon": { "type": "string", "enum": ["primary", "secondary", "draft"], "default": "primary" },
-    "sources": { "type": "array", "items": { "type": "string" } },
-
+    "id": {
+      "type": "string",
+      "pattern": "^flora_[a-z0-9_]+$"
+    },
+    "type": {
+      "const": "flora"
+    },
+    "name": {
+      "type": "string"
+    },
+    "scientific": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "taxonomy": {
+      "type": "object"
+    },
+    "habitats": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "uses": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "related_species": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "string"
+    },
+    "canon": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "draft"
+      ],
+      "default": "primary"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "journal_prompt": {
       "type": "string",
       "description": "Player-facing prose read in the travel journal. Distinct from `notes`: `notes` is a reference fact for the canon reader, `journal_prompt` is the sentence the player sees. Exported as `journalPrompt`."
@@ -39,19 +86,49 @@
       "description": "Tile biomes this species may be placed in. Empty means it is never placed.",
       "items": {
         "type": "string",
-        "enum": ["sea", "coast", "plains", "forest", "wetland", "hills", "mountains", "desert", "river", "settlement", "landmark"]
+        "enum": [
+          "sea",
+          "coast",
+          "plains",
+          "forest",
+          "wetland",
+          "hills",
+          "mountains",
+          "desert",
+          "river",
+          "settlement",
+          "landmark"
+        ]
       }
     },
     "placement": {
       "type": "string",
-      "enum": ["encounter", "flavour", "lore"],
+      "enum": [
+        "encounter",
+        "flavour",
+        "lore"
+      ],
       "description": "Plants placed in play are `flavour`; `lore` is authored but never placed. Untagged imports default to `lore`."
     },
-    "rarity": { "type": "string", "enum": ["common", "rare", "mythic"] },
+    "rarity": {
+      "type": "string",
+      "enum": [
+        "common",
+        "rare",
+        "mythic"
+      ]
+    },
     "epochs": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "Epoch ids from database/timeline/epochs.json. Absent means present in all epochs."
+    },
+    "source_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Position in the authored bestiary sequence (prototype starters first for fauna). Array order decides which species pickFor lands on for a tile, so this is part of the seed contract, not presentation."
     }
   },
   "additionalProperties": true

--- a/utils/export_game_data.py
+++ b/utils/export_game_data.py
@@ -1,0 +1,159 @@
+"""Export canon species to 4000BCESaraswathy's data/creatures.json and data/flora.json.
+
+Phase 2 of the canon/game integration. database/ owns the species canon; the game
+consumes a generated projection of it. This replaces the game's own
+tools/build-species-data.js, which read docs/bestiary.md directly and made the game
+repo a second entity store for the same fiction.
+
+The output shape is dictated by src/world/types.ts. It is not validated here -- the
+game imports the JSON and `npm run typecheck` is the check, which is stricter than
+anything this script could assert about itself.
+
+Two things about the output are load-bearing:
+
+  order   `pickFor` indexes into the per-biome list, so array order decides which
+          creature a given tile shows. It is part of the seed contract. Entities carry
+          `source_index` recording the authored bestiary sequence; anything without one
+          (species authored in canon, absent from the bestiary) sorts after, by id, so
+          adding canon entities can never reshuffle the existing ones.
+
+  format  2-space indent, trailing newline, non-ASCII left unescaped -- matching
+          JSON.stringify(value, null, 2) so diffs against the old generator stay
+          readable. Several species names carry diacritics ("Maya-born"), so
+          ensure_ascii would rewrite every one of them.
+
+Also writes data/canon.lock.json: the canon version and a hash of each exported file,
+so the game's CI can tell that its committed data still matches a known canon release
+rather than having been hand-edited.
+
+    python utils/export_game_data.py                 # dry run, reports the diff
+    python utils/export_game_data.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = Path(os.environ.get("CANON_REPO", REPO.parent / "4000BCESaraswathy")) / "data"
+
+# Field order matters only for diff readability, but a stable order keeps the file from
+# churning. This is the order the previous generator emitted.
+FAUNA_FIELDS = ["id", "name", "binomial", "region", "biomes", "placement", "rarity", "mood", "journalPrompt"]
+FLORA_FIELDS = [f for f in FAUNA_FIELDS if f != "mood"]
+
+# Sorts after every bestiary entry, so canon-only species append rather than interleave.
+UNINDEXED = 10**9
+
+
+def game_id(canon_id: str) -> str:
+    return canon_id.split("_", 1)[1].replace("_", "-")
+
+
+def region_lookup() -> dict[str, str]:
+    """canon region id -> bestiary region slug, for entities that predate the import."""
+    out = {}
+    for f in sorted((REPO / "database" / "regions").glob("*.json")):
+        payload = json.loads(f.read_text(encoding="utf-8"))
+        if "bestiary_region" in payload:
+            out[payload["id"]] = payload["bestiary_region"]
+    return out
+
+
+def to_game(entity: dict, kind: str, regions: dict[str, str]) -> dict:
+    region = entity.get("region")
+    if not region:
+        # Authored in canon rather than imported: recover a region from its habitats.
+        for habitat in entity.get("habitats") or []:
+            if habitat in regions:
+                region = regions[habitat]
+                break
+    out = {
+        "id": game_id(entity["id"]),
+        "name": entity["name"],
+        "binomial": entity.get("scientific") or None,
+        "region": region or "canon",
+        "biomes": entity.get("biomes") or [],
+        "placement": entity.get("placement") or "lore",
+        "rarity": entity.get("rarity") or "common",
+        # `notes` is the canon reference fact and `journal_prompt` the player-facing
+        # prose; they are deliberately separate fields. Entities authored in canon have
+        # only the former, and are all placement "lore" so the player never reads this.
+        "journalPrompt": entity.get("journal_prompt") or entity.get("notes") or "",
+    }
+    if kind == "fauna":
+        out["mood"] = entity.get("mood") or "watchful"
+    fields = FAUNA_FIELDS if kind == "fauna" else FLORA_FIELDS
+    return {f: out[f] for f in fields}
+
+
+def collect(kind: str, regions: dict[str, str]) -> list[dict]:
+    entities = [
+        json.loads(f.read_text(encoding="utf-8"))
+        for f in sorted((REPO / "database" / kind).glob("*.json"))
+    ]
+    entities.sort(key=lambda e: (e.get("source_index", UNINDEXED), e["id"]))
+    return [to_game(e, kind, regions) for e in entities]
+
+
+def render(rows: list[dict]) -> str:
+    return json.dumps(rows, indent=2, ensure_ascii=False) + "\n"
+
+
+# The lock file's hashes are defined over LF-normalised content. Without this, Python's
+# newline translation writes CRLF on Windows while the hash was taken on LF, so the
+# freshness check fails on exactly the machine that generated the file.
+def write_lf(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def read_lf(path: Path) -> str:
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT,
+                    help="the game's data/ directory (env CANON_REPO overrides the repo root)")
+    ap.add_argument("--apply", action="store_true", help="write files; otherwise dry run")
+    args = ap.parse_args()
+
+    if not args.out.is_dir():
+        print(f"ERROR: no such directory: {args.out}", file=sys.stderr)
+        return 1
+
+    index = json.loads((REPO / "database" / "index.json").read_text(encoding="utf-8"))
+    regions = region_lookup()
+
+    outputs = {"creatures.json": collect("fauna", regions), "flora.json": collect("flora", regions)}
+    lock = {"canon_version": index["version"], "counts": {}, "sha256": {}}
+
+    print("APPLIED" if args.apply else "DRY RUN — nothing written")
+    for filename, rows in outputs.items():
+        text = render(rows)
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        lock["counts"][filename] = len(rows)
+        lock["sha256"][filename] = digest
+
+        target = args.out / filename
+        before = read_lf(target) if target.exists() else None
+        state = "unchanged" if before == text else ("new" if before is None else "CHANGED")
+        print(f"  {filename:16} {len(rows):4} entries  {digest[:16]}  {state}")
+        if args.apply:
+            write_lf(target, text)
+
+    if args.apply:
+        write_lf(args.out / "canon.lock.json", json.dumps(lock, indent=2, ensure_ascii=False) + "\n")
+    print(f"  canon version {lock['canon_version']}")
+    if not args.apply:
+        print("\nRe-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/import_bestiary.py
+++ b/utils/import_bestiary.py
@@ -323,6 +323,7 @@ def build_new(kind: str, rec: dict, ident: str) -> dict:
         "placement": rec["placement"],
         "rarity": rec["rarity"],
         "journal_prompt": rec["journal_prompt"],
+        "source_index": rec["source_index"],
         "canon": "primary",
         "sources": ["docs/bestiary.md"],
     }
@@ -335,7 +336,7 @@ def build_new(kind: str, rec: dict, ident: str) -> dict:
 
 # Fields the bestiary can contribute. Anything already present in canon is left alone --
 # this is what implements canon-wins on the seven disputed binomials.
-MERGEABLE = ("region", "biomes", "placement", "rarity", "journal_prompt", "mood")
+MERGEABLE = ("region", "biomes", "placement", "rarity", "journal_prompt", "mood", "source_index")
 
 
 def merge_into(existing: dict, rec: dict, kind: str) -> tuple[dict, list[str]]:
@@ -409,11 +410,17 @@ def main() -> int:
         taken = {p["id"] for entries in canon.values() for _, p in entries}
         records = parse_bestiary(bestiary, kind)
         if kind == "fauna":
-            records += [
+            # The game assembles [...STARTERS, ...parseBestiary('fauna')], and array order
+            # decides which species pickFor lands on for a given tile -- it is part of the
+            # seed contract, not presentation. Record it so the export can reproduce it
+            # without re-reading the bestiary.
+            records = [
                 {"name": n, "binomial": None, "region": "prototype-starters", "biomes": list(b),
                  "placement": "encounter", "rarity": "common", "mood": m, "journal_prompt": j}
                 for n, m, b, j in STARTERS
-            ]
+            ] + records
+        for i, rec in enumerate(records):
+            rec["source_index"] = i
 
         touched: dict[str, dict] = {}
         consumed: set[str] = set()


### PR DESCRIPTION
Phase 2.1-2.3. database/ now owns the species canon, so the game's data/creatures.json and data/flora.json become a projection of it rather than a second entity store built from docs/bestiary.md.

utils/export_game_data.py emits both files in the shape src/world/types.ts dictates. The shape is not validated here -- the game imports the JSON and `npm run typecheck` is a stricter check than anything this script could assert about itself.

Array order turned out to be load-bearing. `pickFor` indexes into the per-biome list, so the order of these arrays decides which creature a given tile shows: it is part of the seed contract, not presentation. Nothing in canon recorded it. Entities now carry `source_index`, backfilled from the authored bestiary sequence (prototype starters first, matching the game's [...STARTERS, ...parseBestiary('fauna')]). Species authored in canon and absent from the bestiary have no index and sort after, by id, so adding canon entities can never reshuffle the existing ones.

The export was verified against the game's committed data before anything was written. Of the original 306 entries, order is preserved exactly and only eight fields changed, all of them intended:

  6  binomials, resolved to canon in Phase 1
  1  River Otter gains "Lutra saraswati" where the game had null
  1  lava-vent-tubeworm-2 becomes lava-vent-tubeworm-asurica

40 entities are appended, every one placement "lore". indexByBiome filters those out, so no encounter table changes and gameplay is untouched -- confirmed by the game's own suite: typecheck, 90 unit tests, build, and all 8 Playwright specs including the full walk-to-landmark playthrough. The SAVE_VERSION bump the plan anticipated is not needed, and saved journeys survive: `observed` stores creature names, and no name changed.

Hashes in data/canon.lock.json are defined over LF-normalised content. Python's newline translation writes CRLF on Windows while the hash is taken on LF, which would have failed the freshness check on exactly the machine that generated the file.