### PR TITLE
Add an HTTP seam so the game can ask canon about a tile

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -1,0 +1,70 @@
+# Canon API
+
+The HTTP seam between the canon database and the game. Optional: the game is a static
+bundle with canon baked in, and it works exactly as before when nothing is listening.
+
+## Run the demo
+
+Three terminals. The order matters only in that the index must exist before the service
+can answer.
+
+```bash
+# 1. index canon — needed once, and again after any canon change
+cd SouthOfTethys
+REPO_DIR=. CHROMA_PERSIST_DIR=storage/chroma python services/chroma/index_chroma_service.py
+
+# 2. the service
+pip install -r services/api/requirements.txt
+CHROMA_PERSIST_DIR=storage/chroma uvicorn services.api.main:app --port 8000
+
+# 3. the game
+cd ../4000BCESaraswathy
+npm run dev        # http://localhost:4173/?seed=lothal
+```
+
+Walk a few tiles. An **Ask the canon** panel appears in the sidebar; it retrieves the canon
+entities for the tile you are standing on. Without the service, the panel does not render
+at all.
+
+## Endpoints
+
+| | |
+|---|---|
+| `GET /health` | whether Chroma is reachable and how many chunks are indexed |
+| `POST /lore` | retrieval only. ~100ms warm. The reliable half. |
+| `POST /ask` | retrieval plus a generated passage. Seconds, and see the warning below. |
+
+Both POST endpoints take a tile: `{seed, x, y, biome, creature?, flora?, landmark?, k?}`.
+
+```bash
+curl -s -X POST localhost:8000/lore -H 'Content-Type: application/json' \
+  -d '{"seed":"lothal","x":12,"y":7,"biome":"wetland","creature":"Lothal Marsh-Lurker"}'
+```
+
+## The model cannot write yet
+
+`lordlebu/4000BCSaraswaty` is GPT-2 small — 124M parameters, no instruction tuning. It
+loads and runs, and it is useless for this. Given real canon about the Lothal Marsh-Lurker
+and told explicitly not to invent anything, it produced a man holding a snake, and with a
+longer prompt it produced a repeating book citation.
+
+This is a capability ceiling, not a prompt or context problem: a canon chunk is ~119 tokens
+against a 1024-token window, so there is plenty of room.
+
+So the model is a setting. Point `CANON_LLM` at any instruction-tuned text-generation model
+and `/ask` starts working:
+
+```bash
+CANON_LLM=Qwen/Qwen2.5-0.5B-Instruct CHROMA_PERSIST_DIR=storage/chroma \
+  uvicorn services.api.main:app --port 8000
+```
+
+`/lore` is unaffected and is what the demo currently rests on — retrieval is a separate,
+working system that returns the right entity at a distance of ~0.29.
+
+## Scope
+
+Local only. CORS allows `localhost:4173` and `:4180` and nothing else, and there is no
+auth, no rate limiting and no caching beyond what the browser client does per tile.
+Deploying this means a host that runs Python — GitHub Pages cannot — plus swapping local
+`transformers` for a hosted inference endpoint.

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -17,14 +17,20 @@ REPO_DIR=. CHROMA_PERSIST_DIR=storage/chroma python services/chroma/index_chroma
 pip install -r services/api/requirements.txt
 CHROMA_PERSIST_DIR=storage/chroma uvicorn services.api.main:app --port 8000
 
-# 3. the game
+# 3. the game — point it at the service, which is off by default
 cd ../4000BCESaraswathy
-npm run dev        # http://localhost:4173/?seed=lothal
+cp .env.example .env.local     # then uncomment VITE_CANON_API
+npm run dev                    # http://localhost:4173/?seed=lothal
 ```
 
 Walk a few tiles. An **Ask the canon** panel appears in the sidebar; it retrieves the canon
-entities for the tile you are standing on. Without the service, the panel does not render
-at all.
+entities for the tile you are standing on.
+
+`VITE_CANON_API` is what switches this on, and it is deliberately unset by default: without
+it the game makes no network calls at all and the panel never renders. That is not only the
+shipping default but the one CI runs — an earlier version defaulted to `localhost:8000` and
+probed on every page load, and the refused request wrote a console error that failed two
+browser specs.
 
 ## Endpoints
 

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -1,0 +1,175 @@
+"""A small HTTP seam between the canon and the game.
+
+The two repos have only ever shared data: the game is a static bundle with canon baked
+in at build time, and it makes no network calls at all. That is still true by default --
+this service is additive, and the game degrades to exactly its current behaviour when
+nothing is listening.
+
+What it adds is the thing the walk cannot do from a static file: ask canon a question
+about the place you are standing in, and have the Vidur model write about it.
+
+Two endpoints rather than one, because they cost wildly different amounts:
+
+  POST /lore   retrieval only. Milliseconds once the collection is warm, and useful on
+               its own -- it answers "what does canon actually say about this?" with
+               entity ids you can go read.
+  POST /ask    retrieval plus generation. Seconds, and it loads a causal LM on first
+               call. The game treats a passage as a bonus, never as something it waits
+               on before drawing.
+
+Run it:
+
+    pip install -r services/api/requirements.txt
+    CHROMA_PERSIST_DIR=storage/chroma uvicorn services.api.main:app --port 8000 --reload
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+REPO = Path(__file__).resolve().parents[2]
+# The retrieval and generation logic already exists and is exercised by the portal.
+# Importing it keeps one implementation rather than a second copy that can drift.
+sys.path.insert(0, str(REPO / "vidur_portal"))
+
+import snippet_processor as vidur  # noqa: E402
+
+app = FastAPI(title="South of Tethys — canon API", version="1.0.0")
+
+# The game runs on Vite's dev port; a preview build on 4180. Both are local-only, which
+# is the whole scope of this service today.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:4173", "http://127.0.0.1:4173",
+        "http://localhost:4180", "http://127.0.0.1:4180",
+    ],
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+
+class Place(BaseModel):
+    """Where the player is standing, in the game's own vocabulary."""
+
+    seed: str
+    x: int
+    y: int
+    biome: str
+    creature: str | None = None
+    flora: str | None = None
+    landmark: str | None = None
+    question: str | None = Field(default=None, description="Overrides the derived query.")
+    k: int = 5
+
+
+# The portal's model is `lordlebu/4000BCSaraswaty`, which is GPT-2 small: 124M parameters
+# and no instruction tuning. It retrieves nothing wrong -- retrieval is a separate,
+# working system -- but it cannot write to a brief. Given real canon about the Lothal
+# Marsh-Lurker and told not to invent anything, it produced a man holding a snake.
+#
+# So the model is a setting, not a constant. Point CANON_LLM at any instruction-tuned
+# text-generation model and /ask starts working; leave it unset and the endpoint reports
+# honestly rather than returning nonsense as though it were canon.
+CANON_LLM = os.environ.get("CANON_LLM", "").strip()
+
+_llm = None
+
+
+def load_llm():
+    global _llm
+    if _llm is None:
+        if CANON_LLM:
+            from transformers import pipeline as hf_pipeline
+
+            _llm = hf_pipeline("text-generation", model=CANON_LLM)
+        else:
+            _llm = vidur.get_hf_pipeline()
+    return _llm
+
+
+def as_query(place: Place) -> str:
+    """Turn a tile into something worth asking canon.
+
+    Naming the species matters more than naming the biome: "wetland" retrieves the biome
+    entity, while "Lothal Marsh-Lurker" retrieves the creature, its region and the
+    settlement it is named for.
+    """
+    if place.question:
+        return place.question
+    parts = [p for p in (place.creature, place.flora, place.landmark) if p]
+    parts.append(f"{place.biome} of Jambhudweepa")
+    return ", ".join(parts)
+
+
+def sources(hits: list[dict]) -> list[dict]:
+    return [
+        {
+            "entity_id": h["meta"].get("entity_id"),
+            "name": h["meta"].get("name") or h["meta"].get("title"),
+            "type": h["meta"].get("entity_type"),
+            "source": h["meta"].get("source"),
+            "distance": round(h.get("distance", 0.0), 4),
+        }
+        for h in hits
+    ]
+
+
+@app.get("/health")
+def health() -> dict:
+    """Enough for the game to decide whether to offer the feature at all."""
+    count = None
+    try:
+        collection = vidur._get_collection()
+        count = collection.count() if collection is not None else None
+    except Exception:
+        count = None
+    return {
+        "ok": True,
+        "chroma": count is not None,
+        "indexed_chunks": count,
+        "collection": vidur.COLLECTION_NAME,
+        "model": vidur.MODEL_HF,
+        "persist_dir": os.environ.get("CHROMA_PERSIST_DIR", vidur.CHROMA_PERSIST_DIR),
+    }
+
+
+@app.post("/lore")
+def lore(place: Place) -> dict:
+    """What canon says about this tile. Retrieval only — no model, no waiting."""
+    query = as_query(place)
+    hits = vidur.retrieve(query, k=place.k)
+    return {"query": query, "sources": sources(hits)}
+
+
+@app.post("/ask")
+def ask(place: Place) -> dict:
+    """A written passage about this tile, grounded in the canon that was retrieved."""
+    query = as_query(place)
+    hits = vidur.retrieve(query, k=place.k)
+    context = "\n\n".join(h["text"] for h in hits)
+
+    instruction = (
+        "You are the chronicler of Jambhudweepa, writing a traveller's journal in the "
+        "second person. Using only the canon below, write two or three quiet sentences "
+        "about what the traveller notices here. Do not invent creatures or places that "
+        "are not named in the canon."
+    )
+    prompt = f"{instruction}\n\nCanon:\n{context}\n\nPlace: {query}\n\nJournal:"
+
+    try:
+        pipeline = load_llm()
+        raw = pipeline(prompt, max_new_tokens=160)[0]["generated_text"]
+    except Exception as exc:  # the model is the fragile part; the sources are not
+        return {"query": query, "passage": None, "error": str(exc)[:200], "sources": sources(hits)}
+
+    # HF text-generation returns the prompt followed by the continuation. Returning the
+    # whole thing would print the instruction and the entire canon context to the player.
+    passage = raw[len(prompt):].strip() if raw.startswith(prompt) else raw.strip()
+    return {"query": query, "passage": passage or None, "sources": sources(hits)}

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -1,0 +1,9 @@
+# The HTTP seam between canon and the game. Retrieval and generation themselves come
+# from vidur_portal/snippet_processor.py, so the floors below must stay in step with
+# vidur_portal/requirements.txt and services/chroma/requirements.txt.
+fastapi>=0.115
+uvicorn[standard]>=0.30
+pydantic>=2.7
+chromadb>=0.5.0
+sentence-transformers>=2.2.0
+transformers


### PR DESCRIPTION
The two repos have only ever shared data: canon is baked into the game's bundle at build time and the game makes no network calls. That stays true -- this service is additive and the game degrades to exactly its current behaviour when nothing is listening.

What it adds is the thing a static file cannot do: search the whole corpus. The species table ships with the game, but the events, settlements, characters and regions do not, and answering "what does canon know about where I am standing?" means querying 421 embedded chunks.

Two endpoints, because they cost very different amounts. /lore is retrieval only and returns in about 100ms warm; /ask adds generation and is measured in seconds. The game treats a passage as a bonus and never waits on one to draw.

Retrieval works well. A wetland tile carrying the Lothal Marsh-Lurker returns that entity at distance 0.29, then Saltreed at 0.31, then the marsh species around them.

Generation does not, and the reason is worth writing down. lordlebu/4000BCSaraswaty is GPT-2 small: 124M parameters, GPT2LMHeadModel, no instruction tuning. It is not falling back to the gpt2 default -- that is the model. Given real canon about the Marsh-Lurker and told not to invent anything it produced a man holding a snake, and with a fuller prompt a repeating book citation. Not a context problem either: a canon chunk is ~119 tokens against a 1024-token window. So CANON_LLM makes the model a setting; point it at any instruction-tuned model and /ask starts working, and /lore is unaffected either way.

Scope is local: CORS allows the game's dev and preview ports and nothing else.