### PR TITLE
Give three species a binomial instead of a description

### DIFF
--- a/database/fauna/fauna_naga_infiltrator.json
+++ b/database/fauna/fauna_naga_infiltrator.json
@@ -2,7 +2,7 @@
   "id": "fauna_naga_infiltrator",
   "type": "fauna",
   "name": "Naga Infiltrator",
-  "scientific": "Serpens anthropomorphic",
+  "scientific": "Serpens simulans",
   "region": "asura-conjurations",
   "biomes": [
     "settlement"
@@ -15,5 +15,8 @@
     "docs/bestiary.md"
   ],
   "mood": "watchful",
-  "source_index": 219
+  "source_index": 219,
+  "taxonomy": {
+    "note": "Was `Serpens anthropomorphic`, English again. `simulans`, one who imitates, for a shape-shifter that passes as human."
+  }
 }

--- a/database/fauna/fauna_naga_kin_sentry.json
+++ b/database/fauna/fauna_naga_kin_sentry.json
@@ -2,7 +2,7 @@
   "id": "fauna_naga_kin_sentry",
   "type": "fauna",
   "name": "Naga-Kin Sentry",
-  "scientific": "Serpens guard",
+  "scientific": "Serpens custos",
   "region": "asura-conjurations",
   "biomes": [
     "settlement"
@@ -15,5 +15,8 @@
     "docs/bestiary.md"
   ],
   "mood": "watchful",
-  "source_index": 230
+  "source_index": 230,
+  "taxonomy": {
+    "note": "Was `Serpens guard` -- an English word where the genus's siblings carry Latin: Serpens obsidianus, Serpens asuricus. `custos`, guardian, in apposition."
+  }
 }

--- a/database/fauna/fauna_nagaraptor.json
+++ b/database/fauna/fauna_nagaraptor.json
@@ -2,7 +2,7 @@
   "id": "fauna_nagaraptor",
   "type": "fauna",
   "name": "Nagaraptor",
-  "scientific": "Proto-Jambhu Dromaeosaur",
+  "scientific": "Nagaraptor vallatus",
   "diet": "Carnivore",
   "habitats": [
     "region_saraswati_delta"
@@ -28,5 +28,8 @@
   "journal_prompt": "Feathered velociraptor clans that have formed a complex diapsid scale-based civilization, using earthworks and moats to defend their nests.",
   "mood": "clever",
   "sentient": true,
-  "source_index": 12
+  "source_index": 12,
+  "taxonomy": {
+    "note": "Was `Proto-Jambhu Dromaeosaur` -- a descriptor, not a binomial. `vallatus`, entrenched, for the earthworks and moats they raise around their nests; adjectival to match the genus's siblings, Vajraptor territorialis and Sylvianus occultus."
+  }
 }


### PR DESCRIPTION
Nagaraptor carried `Proto-Jambhu Dromaeosaur`, which is a label rather than a name, and the two Naga serpents carried English epithets -- `Serpens guard` and `Serpens anthropomorphic` -- while their own genus siblings, Serpens obsidianus and Serpens asuricus, are properly formed.

  Nagaraptor vallatus   entrenched, for the earthworks and moats they raise
                        around their nests. Adjectival, to match Vajraptor
                        territorialis and Sylvianus occultus.
  Serpens custos        guardian, in apposition.
  Serpens simulans      one who imitates, for a shape-shifter that passes.

Found while checking these: scanning all 346 for malformed binomials returns twelve, and nine of them are not malformed at all. Eight fauna named `Maya-born <something>` and two flora named `Rakshasa-Vriksha` are every one of them Asura conjurations -- and a conjured thing has no evolutionary history, so a Linnaean binomial would be a category error. The Sanskrit "born-of" form is a deliberate convention marking what was made rather than what evolved. Left alone, and noted here so the next person to run that scan does not tidy them away.