### PR TITLE
Bump the actions GitHub is about to stop running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -81,10 +81,10 @@ jobs:
       artifacts-generated: ${{ steps.check-artifacts.outputs.generated }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -108,42 +108,42 @@ jobs:
           ls -la cartography/ || true
 
       - name: Upload timeline summary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: timeline_summary
           path: timeline/timeline_summary.md
           if-no-files-found: warn
 
       - name: Upload timeline mermaid artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: timeline_mermaid
           path: timeline/timeline_mermaid.md
           if-no-files-found: warn
 
       - name: Upload full timeline artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full_timeline
           path: timeline/timeline.json
           if-no-files-found: warn
 
       - name: Upload interactive map artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: interactive_map
           path: cartography/interactive_map.html
           if-no-files-found: warn
 
       - name: Upload overworld map artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: overworld_map
           path: cartography/overworld.json
           if-no-files-found: warn
 
       - name: Upload regions geojson artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: regions_geojson
           path: cartography/regions.geojson
@@ -158,10 +158,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -203,10 +203,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/index_changes_sandbox.yml
+++ b/.github/workflows/index_changes_sandbox.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Build with Jekyll

--- a/.github/workflows/push-hf-model.yml
+++ b/.github/workflows/push-hf-model.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -33,7 +33,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/story-validation.yml
+++ b/.github/workflows/story-validation.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -36,7 +36,7 @@ jobs:
         run: python utils/generate_timeline.py
 
       - name: Upload merged timeline artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full_timeline
           path: timeline/timeline.json

--- a/.github/workflows/vidur_portal.yml
+++ b/.github/workflows/vidur_portal.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install dependencies


### PR DESCRIPTION
The runners now warn that actions/checkout@v4, setup-node@v4 and upload-artifact@v4 declare `using: node20`, which is being retired, and are being forced onto Node 24. Nothing of ours runs on Node 20 -- this is the actions' own runtime -- but the forcing is temporary and the warning is the notice.

checkout v4 -> v7, upload/download-artifact v4 -> v7, setup-python v4 and v5 -> v6 (it was inconsistent across workflows, which is its own small trap).

The Pages trio is deliberately untouched: configure-pages, upload-pages-artifact and deploy-pages are the deployment path for the published book, they were not named in the deprecation, and a green check would not prove the site still publishes. Worth doing separately, with someone watching the site.