### PR TITLE
Tell the truth on the model card

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -108,6 +108,29 @@ checked before export. Change the semantics in one, change them in both.
 
 **Entering a gated sub-location** is now `canEnter` / `blockedFrom` in `src/journey.ts`.
 
+## Kept deliberately, not maintained
+
+**The Hugging Face model `lordlebu/4000BCSaraswaty` is stock GPT-2 and nothing uses it**
+(decided 2026-08-13: leave it, document it). It has not been updated in a year because the
+approach was abandoned, not neglected — a 124M base model with no instruction tuning cannot
+write to a brief, which is why the service moved to retrieval plus an instruction-tuned model
+chosen by `CANON_LLM`.
+
+Three things follow, and all three are easy to trip over:
+
+- `model/README.md` is the card HF displays, and it used to claim "a custom causal language
+  model for SouthOfTethys worldbuilding". It now says what the weights actually are. Editing
+  anything under `model/` triggers `push-hf-model.yml`, so that correction reaches HF on merge.
+- `vidur_portal/snippet_processor.py` has a path bug: `LOCAL_CONFIG` resolves *two* levels
+  above the repo, so the local copy is never found and it downloads from the Hub instead. It
+  does not matter today — the Hub copy is GPT-2 and the exception fallback is also `gpt2`, so
+  every path ends at the same model — but it will mislead whoever reads it next.
+- The GitHub Actions secret `HF_TOKEN` is a **write** token whose only consumer is that
+  workflow. Nothing else needs write access; the service uses a separate inference-scoped token.
+
+If the HF presence is ever worth something, publishing canon as a **dataset** is the version
+with value in it — `dataset_card.md` and `dataset_infos.json` already exist unused.
+
 ## Deferred work
 
 **`origin/feature/canon-cleanup-and-design`** — 13 commits, unmerged, predates this work.

--- a/model/README.md
+++ b/model/README.md
@@ -1,26 +1,59 @@
 ---
 language: en
-license: apache-2.0
+license: mit
+library_name: transformers
+pipeline_tag: text-generation
 tags:
   - text-generation
-  - storytelling
-model_type: causal_lm
-pipeline_tag: text-generation
+  - SouthOfTethys
+  - not-fine-tuned
 ---
 
 # 4000BCSaraswaty
 
-A custom causal language model for SouthOfTethys worldbuilding.
+**This is stock GPT-2 small (124M), unmodified. It is not a fine-tuned model, and nothing in
+the South of Tethys project uses it.** It is published here for provenance, and this card
+exists so that nobody mistakes it for the thing its name suggests.
 
----
-tags:
-	- fantasy
-	- procedural-storytelling
-	- SouthOfTethys
-license: mit
-datasets:
-	- lordlebu/SouthOfTethys
-model-index:
-	- name: 4000BCSaraswaty
-		results: []
----
+## What it actually is
+
+An early experiment from the project's first weeks. The intent was to fine-tune a small model
+on the South of Tethys canon; what was published was the base checkpoint, before any training
+happened. The export script still says so in a comment:
+
+```python
+model_name = "gpt2"  # Replace with your fine-tuned model if you have one
+```
+
+No replacement ever happened, and it should not now — see below.
+
+## Why it was never updated
+
+Because the approach was abandoned, and for a good reason rather than through neglect.
+
+GPT-2 small has no instruction tuning. Given real canon about the Lothal Marsh-Lurker and told
+plainly not to invent anything, it produced a description of a man holding a snake. Retrieval
+was never the problem — that part works and is a separate system — but a 124M base model cannot
+write to a brief, and no amount of prompting fixes that.
+
+The project moved to retrieval-augmented generation against an instruction-tuned model, chosen
+at runtime. The live service points at `Qwen/Qwen2.5-7B-Instruct` and never loads this
+checkpoint.
+
+## What to use instead
+
+The canon itself, which is the part with any value in it:
+
+- **Entities** — around 470 authored records: species, regions, places, discoveries, people
+  and vocabulary, in [`database/`](https://github.com/lordlebu/SouthOfTethys) with JSON Schema
+  and a lint that enforces referential integrity.
+- **Retrieval** — a Chroma index over the whole corpus, served behind a small FastAPI service.
+  `/lore` answers "what does canon say about this place" from the entities themselves.
+- **Generation** — any instruction-tuned model, set by environment variable. The service holds
+  no opinion about which, and swapping it is a config change.
+
+## Should you build on this?
+
+No. It is `gpt2`, and you should use `gpt2` — you will get an identical model with a clearer
+name and a proper card. This repository is kept because deleting published artifacts breaks
+links and hides history, not because it is useful.


### PR DESCRIPTION
The HF page has not moved in a year, and the card claimed "a custom causal language model for SouthOfTethys worldbuilding". The weights are stock GPT-2 small, unmodified -- the export script still carries the comment "Replace with your fine-tuned model if you have one", and no replacement ever happened.

Rewritten to say what it is, why it was abandoned rather than neglected (a 124M base model given real canon about the Marsh-Lurker and told not to invent anything produced a man holding a snake), and what to use instead: the canon itself, retrieval over it, and any instruction-tuned model. It ends by saying not to build on this, because `gpt2` is the same thing under a clearer name.

Also fixes a card with two frontmatter blocks and two different licenses.

Editing model/ triggers push-hf-model.yml, so the correction reaches the Hub on merge -- which is the point, since the stale page is a public front door.

docs/decisions.md records the position and the two traps around it: the snippet_processor path bug that quietly downloads from the Hub, and that the HF_TOKEN Actions secret is a write token whose only consumer is that workflow.