### PR TITLE
Split revisit into what the doubt is and when it arrives

### DIFF
--- a/database/field_questions/question_eastern_field.json
+++ b/database/field_questions/question_eastern_field.json
@@ -19,7 +19,8 @@
         "discovery_poisoned_ground"
       ],
       "sound": false,
-      "revisit": "The granary walls are carrying more salt than the field and something is growing out of them."
+      "revisit": "The granary walls are carrying more salt than the field and something is growing out of them.",
+      "revisit_after": "discovery_red_rice_survival"
     },
     {
       "conclusion": "It is salt, weeping up from whatever opened underneath. The soil is not ruined for everything -- only for what they have been planting. The rice on the granary walls has been solving this problem unsupervised for four hundred years.",

--- a/database/field_questions/question_moving_spring.json
+++ b/database/field_questions/question_moving_spring.json
@@ -11,7 +11,8 @@
         "discovery_moving_spring"
       ],
       "sound": false,
-      "revisit": "discovery_moving_spring"
+      "revisit": "There are three basins, in three places, built at three times. A careless surveyor does not build three.",
+      "revisit_after": "discovery_moving_spring"
     },
     {
       "conclusion": "The spring migrates along an opening fault, and has done so at least three times within living memory.",

--- a/database/field_questions/question_silver_water.json
+++ b/database/field_questions/question_silver_water.json
@@ -19,7 +19,8 @@
         "discovery_silver_water"
       ],
       "sound": false,
-      "revisit": "It happens under heavy cloud and at every phase. Whatever the moon is doing, it is not this."
+      "revisit": "It happens under heavy cloud and at every phase. Whatever the moon is doing, it is not this.",
+      "revisit_after": "discovery_dockyard_reef"
     },
     {
       "conclusion": "A bloom rises in the closed basin when rain freshens its surface; the small fish follow the bloom and everything else follows the small fish. The Kia phrase says the same thing in four words and does not pretend to a mechanism.",

--- a/database/field_questions/question_terrace_purpose.json
+++ b/database/field_questions/question_terrace_purpose.json
@@ -11,7 +11,8 @@
         "discovery_terrace_water"
       ],
       "sound": false,
-      "revisit": "discovery_terrace_script"
+      "revisit": "The marks are cut on the inner faces, where nothing meant to be seen would put them.",
+      "revisit_after": "discovery_terrace_script"
     },
     {
       "conclusion": "Grazing platforms cut by the herders' own ancestors.",
@@ -19,7 +20,8 @@
         "discovery_terrace_water"
       ],
       "sound": false,
-      "revisit": "discovery_terrace_water"
+      "revisit": "The fall runs along the hill rather than down it. Nobody levels two hundred courses for goats.",
+      "revisit_after": "discovery_terrace_water"
     },
     {
       "conclusion": "Contour irrigation on a scale requiring a population the archive has no record of.",

--- a/database/field_questions/question_two_names.json
+++ b/database/field_questions/question_two_names.json
@@ -11,7 +11,8 @@
         "discovery_double_classified"
       ],
       "sound": false,
-      "revisit": "discovery_double_classified"
+      "revisit": "The heavy-billed ones are all old ones. The bill does not stop growing when the bird does.",
+      "revisit_after": "discovery_double_classified"
     },
     {
       "conclusion": "One species. The bill grows throughout life, and the two entries are a young bird and an old one, catalogued sixty years apart by observers who never read each other.",

--- a/database/schemas/field_question.schema.json
+++ b/database/schemas/field_question.schema.json
@@ -3,49 +3,122 @@
   "title": "Field Question",
   "description": "A question Varuna cannot answer alone. The signature mechanic: he writes down what he does not understand, and the player gathers evidence until the entry can be closed.\n\nA question is deliberately answerable more than one way. `resolutions` lists the readings the evidence can support -- including wrong ones -- because a naturalist who cannot be mistaken is not doing fieldwork.",
   "type": "object",
-  "required": ["id", "type", "question", "discipline"],
+  "required": [
+    "id",
+    "type",
+    "question",
+    "discipline"
+  ],
   "properties": {
-    "id": { "type": "string", "pattern": "^question_[a-z0-9_]+$" },
-    "type": { "const": "field_question" },
-    "question": { "type": "string", "description": "As Varuna writes it, in the diary. First person, and genuinely uncertain." },
+    "id": {
+      "type": "string",
+      "pattern": "^question_[a-z0-9_]+$"
+    },
+    "type": {
+      "const": "field_question"
+    },
+    "question": {
+      "type": "string",
+      "description": "As Varuna writes it, in the diary. First person, and genuinely uncertain."
+    },
     "discipline": {
       "type": "string",
-      "enum": ["zoology", "botany", "archaeology", "geography", "linguistics", "evolution", "anomalies"]
+      "enum": [
+        "zoology",
+        "botany",
+        "archaeology",
+        "geography",
+        "linguistics",
+        "evolution",
+        "anomalies"
+      ]
     },
-
-    "raised_at": { "type": "string", "description": "point_of_interest id where the question occurs to him." },
-    "raised_by": { "type": "string", "description": "Optional npc id -- often a question starts as something a local says in passing." },
-
+    "raised_at": {
+      "type": "string",
+      "description": "point_of_interest id where the question occurs to him."
+    },
+    "raised_by": {
+      "type": "string",
+      "description": "Optional npc id -- often a question starts as something a local says in passing."
+    },
     "evidence": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "description": "discovery ids that bear on the question. The player does not need all of them; `resolutions` says how many and which."
     },
-
     "resolutions": {
       "type": "array",
       "minItems": 1,
       "description": "The readings the evidence can support. More than one may be reachable, and at most one should be marked `sound` -- the others are honest mistakes a careful person could make.",
       "items": {
         "type": "object",
-        "required": ["conclusion", "requires"],
+        "required": [
+          "conclusion",
+          "requires"
+        ],
         "properties": {
-          "conclusion": { "type": "string", "description": "What Varuna concludes, in his voice." },
-          "requires": { "type": "array", "items": { "type": "string" }, "description": "discovery ids that must be held to reach this reading." },
-          "sound": { "type": "boolean", "default": false, "description": "Whether this reading survives later evidence. A false one should still feel reasonable when it is chosen." },
-          "revisit": { "type": "string", "description": "What later shows this reading was wrong, if anything does. This is how the diary earns a second look months on." }
+          "conclusion": {
+            "type": "string",
+            "description": "What Varuna concludes, in his voice."
+          },
+          "requires": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "discovery ids that must be held to reach this reading."
+          },
+          "sound": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether this reading survives later evidence. A false one should still feel reasonable when it is chosen."
+          },
+          "revisit": {
+            "type": "string",
+            "description": "The observation that eventually troubles this reading, in the words a field diary would use. Prose, not an id -- see revisit_after for when."
+          },
+          "revisit_after": {
+            "type": "string",
+            "description": "The discovery that puts the player in a position to make that observation. The game raises the doubt only once this has been seen, so settling on a wrong reading is not announced as wrong at the moment of choosing."
+          }
         },
         "additionalProperties": true
       }
     },
-
-    "local_knowledge": { "type": "string", "description": "How the people who live here explain it. Not to be treated as folklore to be corrected -- it is often right, in its own terms." },
-    "academic_hypothesis": { "type": "string", "description": "How a Narmada scholar would explain it. Equally often wrong." },
-
-    "epochs": { "type": "array", "items": { "type": "string" } },
-    "notes": { "type": "string" },
-    "canon": { "type": "string", "enum": ["primary", "secondary", "draft"], "default": "primary" },
-    "sources": { "type": "array", "items": { "type": "string" } }
+    "local_knowledge": {
+      "type": "string",
+      "description": "How the people who live here explain it. Not to be treated as folklore to be corrected -- it is often right, in its own terms."
+    },
+    "academic_hypothesis": {
+      "type": "string",
+      "description": "How a Narmada scholar would explain it. Equally often wrong."
+    },
+    "epochs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "string"
+    },
+    "canon": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "draft"
+      ],
+      "default": "primary"
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
   },
   "additionalProperties": true
 }


### PR DESCRIPTION
`revisit` had drifted into two meanings because nothing read it: prose in the Lothal questions ("It happens under heavy cloud and at every phase") and a discovery id in the Narmada ones. Both are worth having and they are not the same thing -- the prose is the observation that troubles a reading, the id is when the player is in a position to make it.

`revisit` is now prose everywhere and `revisit_after` names the discovery. That pairing is what lets a wrong answer stay unchallenged at the moment it is given: the game raises the doubt only once the player has found the thing that raises it, which is when they would have started doubting anyway. Announcing it on commit would turn a mistake into a wrong-answer buzzer and remove the reason to keep looking.

Six unsound readings across five questions now name both.