### PR TITLE
Dwarka, where the method runs out of natural explanations

### DIFF
--- a/database/discoveries/discovery_fever_root_spread.json
+++ b/database/discoveries/discovery_fever_root_spread.json
@@ -1,0 +1,47 @@
+{
+  "id": "discovery_fever_root_spread",
+  "type": "discovery",
+  "name": "Something Is Doing Well Here",
+  "discipline": "botany",
+  "found_at": [
+    "poi_salt_orchard"
+  ],
+  "levels": [
+    {
+      "entry": "The seaward orchard rows are dead of salt. In among them something is thriving that I do not recognise."
+    },
+    {
+      "entry": "Thick leaf, no wax, and it is fruiting in the shade of dead trees in the wrong season."
+    },
+    {
+      "entry": "It is not salt-tolerant, it is salt-indifferent -- the soil chemistry does not appear to be a variable for it at all."
+    },
+    {
+      "entry": "Nothing eats it. Not the goats, not the insects, not the rot. In a delta, that is a stranger fact than the leaf shape."
+    },
+    {
+      "entry": "It is spreading at about a pace a year, along the dead rows, and no farmer here is worried because it grows where nothing grows."
+    },
+    {
+      "entry": "Which is the mistake. It is not filling ground nothing wanted. It is making ground that nothing else can use, and it is doing it slowly enough that nobody has thought to measure.",
+      "requires": [
+        "discovery_midden_layers"
+      ]
+    }
+  ],
+  "helps": [
+    "npc_sura"
+  ],
+  "restores": [
+    "poi_salt_orchard"
+  ],
+  "notes": "An establishment event in progress, which is slower and worse than a monster. The last rung is the only place on this map where the player knows something the locals do not.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_gate_rhythm.json
+++ b/database/discoveries/discovery_gate_rhythm.json
@@ -1,0 +1,47 @@
+{
+  "id": "discovery_gate_rhythm",
+  "type": "discovery",
+  "name": "What the Gate Keeps Time With",
+  "discipline": "anomalies",
+  "found_at": [
+    "poi_gate_court",
+    "poi_watch_stair"
+  ],
+  "levels": [
+    {
+      "entry": "There is a doorway in the court that people walk around rather than through. Nobody has told me not to. I have not."
+    },
+    {
+      "entry": "It is not always doing anything. Most of the day it is a doorway in a wall."
+    },
+    {
+      "entry": "In mist it is doing something. The air on the far side is a different air -- warmer, and it smells of stone rather than salt.",
+      "conditions": {
+        "weather": [
+          "mist"
+        ]
+      }
+    },
+    {
+      "entry": "Not the tide, then, and not the hour. I sat the stair for three days with a slate and the only thing that matches is the mist."
+    },
+    {
+      "entry": "Which is backwards. Mist is water in air; it does not open anything. Unless the mist and the opening are both downstream of a third thing, and I have been watching the wrong one."
+    },
+    {
+      "entry": "Pell says the sweeping is done at mist and always has been. Nobody decided that. It is simply when there is something to sweep."
+    }
+  ],
+  "answers": [
+    "question_what_comes_through"
+  ],
+  "notes": "The anomaly, approached as a naturalist would: rule out the tide, rule out the hour, notice the correlation, then notice the correlation is not a cause. Ends honestly short of an explanation.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_market_ledger.json
+++ b/database/discoveries/discovery_market_ledger.json
@@ -1,0 +1,38 @@
+{
+  "id": "discovery_market_ledger",
+  "type": "discovery",
+  "name": "Two Mornings a Day",
+  "discipline": "geography",
+  "found_at": [
+    "poi_tide_market"
+  ],
+  "levels": [
+    {
+      "entry": "The market opens twice and closes twice, and everyone knows when without being told."
+    },
+    {
+      "entry": "It is the tide, obviously. What is less obvious is that the tide here is not the tide at Lothal."
+    },
+    {
+      "entry": "A ledger goes back sixty years of opening times. Nobody kept it for the tide; they kept it for the tolls."
+    },
+    {
+      "entry": "Read as a tide record it is better than anything the University has, and it says the high water is arriving later each decade.",
+      "requires": [
+        "discovery_seawall_courses"
+      ]
+    }
+  ],
+  "answers": [
+    "question_what_ends_dwarka"
+  ],
+  "notes": "Local record-keeping outperforming the academy again, and this time entirely by accident -- the ledger was for taxes.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_midden_layers.json
+++ b/database/discoveries/discovery_midden_layers.json
@@ -1,0 +1,41 @@
+{
+  "id": "discovery_midden_layers",
+  "type": "discovery",
+  "name": "How Often This Has Happened",
+  "discipline": "archaeology",
+  "found_at": [
+    "poi_bone_midden"
+  ],
+  "levels": [
+    {
+      "entry": "The midden is layered like any midden: fish, shell, pot, ash, fish, shell, pot."
+    },
+    {
+      "entry": "There are other layers. Thin ones, of bone I cannot place, and they are not at the top."
+    },
+    {
+      "entry": "I counted nine. The deepest is under a pottery style Sura says her grandmother's grandmother used."
+    },
+    {
+      "entry": "Nine, in four hundred years, and not evenly spaced -- they cluster. Two of them are close enough to be one bad decade."
+    },
+    {
+      "entry": "This is not an event. It is a climate. Dwarka has been dealing with this the whole time it has existed, and has a word for it, and a place to put the remains."
+    }
+  ],
+  "answers": [
+    "question_what_comes_through"
+  ],
+  "helps": [
+    "npc_sura"
+  ],
+  "notes": "Turns the anomaly from an incident into a condition, which is the map's whole argument. The clustering is left unexplained on purpose.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_seawall_courses.json
+++ b/database/discoveries/discovery_seawall_courses.json
@@ -1,0 +1,46 @@
+{
+  "id": "discovery_seawall_courses",
+  "type": "discovery",
+  "name": "Three Walls Against One Sea",
+  "discipline": "geography",
+  "found_at": [
+    "poi_drowned_seawall"
+  ],
+  "levels": [
+    {
+      "entry": "There are three seawalls here, not one. I assumed rebuilding. It is not rebuilding -- all three still stand."
+    },
+    {
+      "entry": "Each is founded a little higher than the one seaward of it, and each is built of what was cheap that century."
+    },
+    {
+      "entry": "The outermost is under water at every tide now. It was not built to be.",
+      "conditions": {
+        "time_of_day": [
+          "dawn"
+        ]
+      }
+    },
+    {
+      "entry": "Roughly a hand of sea in a hundred years, if the walls were built dry-footed. Slow enough that no single person ever saw it happen."
+    },
+    {
+      "entry": "The gate gets swept and the sea gets a new wall. Only one of those is going to finish the city, and it is not the interesting one."
+    }
+  ],
+  "answers": [
+    "question_what_ends_dwarka"
+  ],
+  "helps": [
+    "npc_pell"
+  ],
+  "notes": "The sober counterweight. A map about a supernatural door should be clear that the thing actually destroying the place is ordinary sea-level rise.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_wrong_anatomy.json
+++ b/database/discoveries/discovery_wrong_anatomy.json
@@ -1,0 +1,42 @@
+{
+  "id": "discovery_wrong_anatomy",
+  "type": "discovery",
+  "name": "A Skeleton That Does Not Fit",
+  "discipline": "evolution",
+  "found_at": [
+    "poi_bone_midden",
+    "poi_gate_court"
+  ],
+  "levels": [
+    {
+      "entry": "A partial skeleton in the midden, picked over. Not fish, not bird, not anything I can put a name to."
+    },
+    {
+      "entry": "The limb bones are paired the wrong way. Whatever this was did not share an ancestor with anything I have drawn on this continent."
+    },
+    {
+      "entry": "Not deformity, and not two animals mixed: the joints articulate. It worked. Something walked around inside this."
+    },
+    {
+      "entry": "The teeth are the argument. Replacement runs from the back forward, which nothing here does, and the wear says it lived long enough to be old."
+    },
+    {
+      "entry": "So it did not arrive as a curiosity in somebody's cargo. It arrived, and then it lived, and then it died here and was thrown out with the fish spine.",
+      "requires": [
+        "discovery_midden_layers"
+      ]
+    }
+  ],
+  "answers": [
+    "question_what_comes_through"
+  ],
+  "notes": "The evolution discovery, and the one that makes the academy's answers untenable. Deliberately unglamorous -- the remarkable thing is in a rubbish heap, because that is where the city put it.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/field_maps/field_map_dwarka.json
+++ b/database/field_maps/field_map_dwarka.json
@@ -1,0 +1,40 @@
+{
+  "id": "field_map_dwarka",
+  "type": "field_map",
+  "name": "Dwarka",
+  "region": "region_saraswati_delta",
+  "seed_biomes": [
+    "coast",
+    "settlement",
+    "wetland",
+    "river"
+  ],
+  "scale": "small",
+  "points_of_interest": [
+    "poi_tide_market",
+    "poi_gate_court",
+    "poi_drowned_seawall",
+    "poi_bone_midden",
+    "poi_salt_orchard",
+    "poi_watch_stair"
+  ],
+  "neighbours": [
+    "field_map_lothal"
+  ],
+  "climate": {
+    "clear": 44,
+    "mist": 30,
+    "rain": 18,
+    "storm": 8
+  },
+  "arrival": "Half of Dwarka is under water and the half that is not has been rebuilt twice on top of itself. Nobody here treats the sea as an enemy or the gate as a wonder. Both are simply conditions, like weather, and the whole city is arranged around living beside them.",
+  "notes": "Third field map. The one where the method is tested: local knowledge is not merely useful here, it is right, and the academy's three tidy explanations are all wrong. Gives `crosses_at` a consumer without making the crossing species placeable -- you find what they left, never the animal.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/field_maps/field_map_lothal.json
+++ b/database/field_maps/field_map_lothal.json
@@ -29,6 +29,7 @@
     "AI_CONTEXT.md"
   ],
   "neighbours": [
+    "field_map_dwarka",
     "field_map_narmada"
   ],
   "climate": {

--- a/database/field_questions/question_what_comes_through.json
+++ b/database/field_questions/question_what_comes_through.json
@@ -1,0 +1,54 @@
+{
+  "id": "question_what_comes_through",
+  "type": "field_question",
+  "question": "There are animals in this midden that belong to no lineage on this continent, at a city whose people say a door opens in the mist. I have three respectable explanations and I am losing confidence in all of them.",
+  "discipline": "anomalies",
+  "raised_at": "poi_bone_midden",
+  "raised_by": "npc_sura",
+  "evidence": [
+    "discovery_wrong_anatomy",
+    "discovery_midden_layers",
+    "discovery_gate_rhythm"
+  ],
+  "resolutions": [
+    {
+      "conclusion": "Vagrants and escaped stock from a trading city, misremembered into a story about a door.",
+      "requires": [
+        "discovery_wrong_anatomy"
+      ],
+      "sound": false,
+      "revisit": "Nine layers, over four hundred years, of animals that share no ancestor with anything on this coast. Trade does not do that, and it does not do it in clusters.",
+      "revisit_after": "discovery_midden_layers"
+    },
+    {
+      "conclusion": "A relict population from before the Shattering, surviving in the drowned quarter and coming ashore.",
+      "requires": [
+        "discovery_wrong_anatomy",
+        "discovery_midden_layers"
+      ],
+      "sound": false,
+      "revisit": "A relict lineage would still be a lineage. These share no ancestor with anything here, and no two layers share one with each other.",
+      "revisit_after": "discovery_gate_rhythm"
+    },
+    {
+      "conclusion": "They cross. The gate is real, it is not rare, and the people who live beside it have been correct about it for four hundred years while being unable to say why.",
+      "requires": [
+        "discovery_wrong_anatomy",
+        "discovery_midden_layers",
+        "discovery_gate_rhythm"
+      ],
+      "sound": true
+    }
+  ],
+  "local_knowledge": "Sura will tell you the gate opens in mist, that you sweep after, and that the bones go in the midden with everything else. She is not being mystical. She is telling you the procedure, the way you would explain bins.",
+  "academic_hypothesis": "The Narmada position is that Dwarka is a trading port with an old story and poor record-keeping, and that every specimen produced so far has been either a misidentified juvenile or a hoax. No scholar has been to the midden.",
+  "notes": "The map's thesis, and the one question in the game where the local account is simply correct and the academy simply wrong. Both wrong readings are respectable and one of them is what a good naturalist would reach for second.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/field_questions/question_what_ends_dwarka.json
+++ b/database/field_questions/question_what_ends_dwarka.json
@@ -1,0 +1,42 @@
+{
+  "id": "question_what_ends_dwarka",
+  "type": "field_question",
+  "question": "The city is being lost. I would like to be able to say to somebody in authority what is losing it, and I notice I want the answer to be the interesting one.",
+  "discipline": "geography",
+  "raised_at": "poi_drowned_seawall",
+  "raised_by": "npc_pell",
+  "evidence": [
+    "discovery_seawall_courses",
+    "discovery_market_ledger"
+  ],
+  "resolutions": [
+    {
+      "conclusion": "The gate. Whatever comes through is taking the place apart by degrees.",
+      "requires": [
+        "discovery_seawall_courses"
+      ],
+      "sound": false,
+      "revisit": "Three walls, sixty years of toll ledgers, and a hand of sea a century. Nothing that came through the court has moved a single course of stone.",
+      "revisit_after": "discovery_market_ledger"
+    },
+    {
+      "conclusion": "The sea, rising slowly enough that no one person has ever watched it happen, and no more mysterious than that.",
+      "requires": [
+        "discovery_seawall_courses",
+        "discovery_market_ledger"
+      ],
+      "sound": true
+    }
+  ],
+  "local_knowledge": "Pell has rebuilt the inner wall once in his life and expects his son to do it again. He does not connect that to anything; it is simply what the wall is for.",
+  "academic_hypothesis": "The survey of 402 records the Dwarka coastline as stable, on the basis of a single visit and the outermost wall being described as a breakwater.",
+  "notes": "The counterweight question, and the one where the player's own appetite for a good story is the thing being tested. The unsound reading is the one this map has spent the whole time making attractive.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/index.json
+++ b/database/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "SouthOfTethys canonical entity index",
   "counts": {
     "characters": 41,
@@ -11,12 +11,12 @@
     "artifacts": 3,
     "factions": 3,
     "mythology": 3,
-    "field_maps": 2,
-    "points_of_interest": 12,
-    "discoveries": 18,
-    "field_questions": 5,
-    "npcs": 6,
-    "vocabulary": 6
+    "field_maps": 3,
+    "points_of_interest": 18,
+    "discoveries": 24,
+    "field_questions": 7,
+    "npcs": 8,
+    "vocabulary": 8
   },
   "entities": {
     "characters": [
@@ -455,22 +455,29 @@
       "mythology_varuna"
     ],
     "field_maps": [
+      "field_map_dwarka",
       "field_map_lothal",
       "field_map_narmada"
     ],
     "points_of_interest": [
       "poi_basalt_quarry",
+      "poi_bone_midden",
       "poi_cloud_stair",
       "poi_drowned_dockyard",
+      "poi_drowned_seawall",
       "poi_eastern_field",
+      "poi_gate_court",
       "poi_herders_terraces",
       "poi_kavik_tower",
       "poi_long_archive",
       "poi_lothal_camp",
       "poi_marsh_shrine",
       "poi_narmada_university",
+      "poi_salt_orchard",
       "poi_silted_granary",
-      "poi_walking_spring"
+      "poi_tide_market",
+      "poi_walking_spring",
+      "poi_watch_stair"
     ],
     "discoveries": [
       "discovery_archive_baseline",
@@ -479,38 +486,50 @@
       "discovery_dockyard_reef",
       "discovery_double_classified",
       "discovery_escarpment_wind",
+      "discovery_fever_root_spread",
+      "discovery_gate_rhythm",
       "discovery_ghost_mangrove_channel",
+      "discovery_market_ledger",
       "discovery_marsh_lurker_habits",
       "discovery_mask_niche",
+      "discovery_midden_layers",
       "discovery_moving_spring",
       "discovery_poisoned_ground",
       "discovery_quarry_sequence",
       "discovery_red_rice_survival",
       "discovery_saltreed_thatch",
+      "discovery_seawall_courses",
       "discovery_silver_water",
       "discovery_terrace_script",
       "discovery_terrace_water",
-      "discovery_tower_collapse"
+      "discovery_tower_collapse",
+      "discovery_wrong_anatomy"
     ],
     "field_questions": [
       "question_eastern_field",
       "question_moving_spring",
       "question_silver_water",
       "question_terrace_purpose",
-      "question_two_names"
+      "question_two_names",
+      "question_what_comes_through",
+      "question_what_ends_dwarka"
     ],
     "npcs": [
       "npc_bekh",
       "npc_marn",
       "npc_okhi",
+      "npc_pell",
+      "npc_sura",
       "npc_thrali",
       "npc_uma",
       "npc_vessa"
     ],
     "vocabulary": [
+      "word_kia_ossu",
       "word_kia_thal",
       "word_kia_thal_set",
       "word_kia_uvai",
+      "word_kia_vaath",
       "word_maru_anu",
       "word_maru_khet",
       "word_maru_sev"

--- a/database/npcs/npc_pell.json
+++ b/database/npcs/npc_pell.json
@@ -1,0 +1,49 @@
+{
+  "id": "npc_pell",
+  "type": "npc",
+  "name": "Pell",
+  "role": "wall-keeper and sweeper",
+  "found_at": [
+    "poi_gate_court",
+    "poi_tide_market"
+  ],
+  "language": "kia",
+  "would_settle": false,
+  "knows": [
+    "discovery_gate_rhythm",
+    "discovery_seawall_courses",
+    "question_what_ends_dwarka"
+  ],
+  "lines": [
+    {
+      "text": "I keep the inner wall and I sweep the court. They are the same job to me: something arrives, and it has to go somewhere.",
+      "gives": [
+        "question_what_ends_dwarka"
+      ]
+    },
+    {
+      "text": "In mist, yes. Not every mist. You will want the stair and three days, and you will be the first person to sit them who was not being paid.",
+      "requires": [
+        "discovery_gate_rhythm"
+      ],
+      "gives": [
+        "word_kia_vaath"
+      ]
+    },
+    {
+      "text": "No. My father rebuilt this wall and I have rebuilt it and my son will. You are asking me to leave a job that is not finished, and it is never going to be finished, and that is not a reason.",
+      "requires": [
+        "discovery_seawall_courses"
+      ]
+    }
+  ],
+  "notes": "The one who will not come, and for the opposite reason to Bekh: not somebody has to stay, but the work does not end and that is not an argument for stopping. Sweeps an interdimensional gate as municipal maintenance.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/npcs/npc_sura.json
+++ b/database/npcs/npc_sura.json
@@ -1,0 +1,50 @@
+{
+  "id": "npc_sura",
+  "type": "npc",
+  "name": "Sura",
+  "role": "bone-picker",
+  "found_at": [
+    "poi_bone_midden",
+    "poi_salt_orchard",
+    "poi_tide_market"
+  ],
+  "language": "kia",
+  "would_settle": true,
+  "knows": [
+    "discovery_midden_layers",
+    "discovery_wrong_anatomy",
+    "question_what_comes_through"
+  ],
+  "lines": [
+    {
+      "text": "Everything the city cannot use comes to me eventually. Most of it is fish. Some years it is not.",
+      "gives": [
+        "question_what_comes_through"
+      ]
+    },
+    {
+      "text": "You want the thin layers. My mother showed me where they are, and hers showed her, and none of us has ever been asked about them before today.",
+      "requires": [
+        "discovery_wrong_anatomy"
+      ],
+      "gives": [
+        "word_kia_ossu"
+      ]
+    },
+    {
+      "text": "The orchard? The orchard is finished. I would rather you told me something about it that I can do than something about it that is true.",
+      "requires": [
+        "discovery_fever_root_spread"
+      ]
+    }
+  ],
+  "notes": "Holds four hundred years of stratigraphy as a family trade and has never been asked. Would settle -- the midden is a living, not a home.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_bone_midden.json
+++ b/database/points_of_interest/poi_bone_midden.json
@@ -1,0 +1,29 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dwarka",
+  "id": "poi_bone_midden",
+  "name": "The Bone Midden",
+  "kind": "archaeological_site",
+  "terrain": [
+    "coast",
+    "wetland"
+  ],
+  "discoveries": [
+    "discovery_midden_layers",
+    "discovery_wrong_anatomy"
+  ],
+  "npcs": [
+    "npc_sura"
+  ],
+  "description": "Where the city puts what it cannot eat, cannot burn, and does not want.",
+  "arrival": "Every settlement has a midden and this one has the usual fish spine and oyster shell and broken pot. It also has, at intervals, layers of something else — and the intervals are the interesting part.",
+  "notes": "Evidence rather than encounter. The crossing species stay `lore` and unplaceable; what the player finds is what they left.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_drowned_seawall.json
+++ b/database/points_of_interest/poi_drowned_seawall.json
@@ -1,0 +1,25 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dwarka",
+  "id": "poi_drowned_seawall",
+  "name": "The Drowned Seawall",
+  "kind": "archaeological_site",
+  "terrain": [
+    "coast",
+    "wetland"
+  ],
+  "discoveries": [
+    "discovery_seawall_courses"
+  ],
+  "description": "Three seawalls, one behind the other, each built when the last stopped working.",
+  "arrival": "You can wade the outermost at low water and stand on the innermost without getting your feet wet, and between them is four hundred years of a city agreeing, twice, that the sea had won that round.",
+  "notes": "The geography discovery and the sober counterweight to the gate: the thing actually destroying Dwarka is the sea, which nobody finds remarkable either.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_gate_court.json
+++ b/database/points_of_interest/poi_gate_court.json
@@ -1,0 +1,48 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dwarka",
+  "id": "poi_gate_court",
+  "name": "The Gate Court",
+  "kind": "anomaly",
+  "terrain": [
+    "settlement",
+    "coast"
+  ],
+  "related_entities": [
+    "settlement_dwarka",
+    "event_shadow_pact"
+  ],
+  "discoveries": [
+    "discovery_gate_rhythm",
+    "discovery_wrong_anatomy"
+  ],
+  "npcs": [
+    "npc_pell"
+  ],
+  "sub_locations": [
+    {
+      "id": "outer_court",
+      "name": "The Outer Court",
+      "description": "Paving, a drain, and a low wall someone maintains. It looks like a yard because it is one."
+    },
+    {
+      "id": "the_threshold",
+      "name": "The Threshold",
+      "description": "Where the air stops being the same on both sides. You can stand with one hand in each and feel the difference at the wrist.",
+      "requires": [
+        "discovery_gate_rhythm"
+      ]
+    }
+  ],
+  "description": "A swept courtyard with a doorway in it that does not lead anywhere in this city.",
+  "arrival": "It is swept. That is the first thing, and it undoes most of what you were prepared for: somebody sweeps the gate court, the way somebody sweeps a threshing floor, because things come through and the mess has to go somewhere.",
+  "notes": "The anomaly, presented as municipal infrastructure. The horror of it, if there is any, is entirely in how unremarkable the locals find it.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_salt_orchard.json
+++ b/database/points_of_interest/poi_salt_orchard.json
@@ -1,0 +1,28 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dwarka",
+  "id": "poi_salt_orchard",
+  "name": "The Salt Orchard",
+  "kind": "eco_site",
+  "terrain": [
+    "wetland",
+    "coast"
+  ],
+  "discoveries": [
+    "discovery_fever_root_spread"
+  ],
+  "npcs": [
+    "npc_sura"
+  ],
+  "description": "Fruit trees dying at one end and something else doing well at the other.",
+  "arrival": "The orchard is half orchard. The seaward rows are salt-killed and standing, and through them, in the shade the dead trees still cast, something with the wrong leaf shape is doing extremely well.",
+  "notes": "The botany discovery. An establishment event in progress, which is a slower and more frightening thing than a monster.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_tide_market.json
+++ b/database/points_of_interest/poi_tide_market.json
@@ -1,0 +1,31 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dwarka",
+  "id": "poi_tide_market",
+  "name": "The Tide Market",
+  "kind": "settlement",
+  "terrain": [
+    "settlement"
+  ],
+  "related_entities": [
+    "settlement_dwarka"
+  ],
+  "discoveries": [
+    "discovery_market_ledger"
+  ],
+  "npcs": [
+    "npc_sura",
+    "npc_pell"
+  ],
+  "description": "Trading twice a day, around a tide that decides when the floor is a floor.",
+  "arrival": "The market runs on the low water and stops on the high, so the day has two mornings and two evenings and everybody's sense of time is bent around it. Prices are quoted in what the tide will allow rather than in what a thing is worth.",
+  "notes": "Where the people are. Deliberately ordinary: the point of Dwarka is that the extraordinary thing is treated as weather.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_watch_stair.json
+++ b/database/points_of_interest/poi_watch_stair.json
@@ -1,0 +1,25 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dwarka",
+  "id": "poi_watch_stair",
+  "name": "The Watch Stair",
+  "kind": "wilderness",
+  "terrain": [
+    "coast",
+    "settlement"
+  ],
+  "discoveries": [
+    "discovery_gate_rhythm"
+  ],
+  "description": "Steps up the old wall, kept clear, with a good view of the court.",
+  "arrival": "Somebody keeps these steps clear of weed, and there is a worn patch at the top where people stand. They are not watching the sea from here.",
+  "notes": "The observation post. Exists so the gate can be watched over time rather than visited once, which is what its discovery needs.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/vocabulary/word_kia_ossu.json
+++ b/database/vocabulary/word_kia_ossu.json
@@ -1,0 +1,20 @@
+{
+  "type": "vocabulary",
+  "language": "kia",
+  "id": "word_kia_ossu",
+  "word": "ossu",
+  "gloss": "the thin layer",
+  "literal": "not-ours bone",
+  "learned_from": [
+    "npc_sura"
+  ],
+  "notes": "A stratigraphic term in a language with no word for stratigraphy. The bone-pickers needed to tell each other which layer they meant.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/vocabulary/word_kia_vaath.json
+++ b/database/vocabulary/word_kia_vaath.json
@@ -1,0 +1,20 @@
+{
+  "type": "vocabulary",
+  "language": "kia",
+  "id": "word_kia_vaath",
+  "word": "vaath",
+  "gloss": "a mist that opens",
+  "literal": "the other side's weather",
+  "learned_from": [
+    "npc_pell"
+  ],
+  "notes": "Distinguishes the mist that does something from the mist that does not, which is a distinction the University has no vocabulary for and no reason to want.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}


### PR DESCRIPTION
The third field map, and the one the other two were setting up. Lothal taught the player to look. Narmada put them inside an institution that is careful, generous and wrong in one structural way. Dwarka tests the method itself: there are animals in the midden that share no ancestor with anything on this continent, at a city whose people say a door opens in the mist -- and here the local account is simply correct while the academy's three respectable answers are all wrong.

It gives `crosses_at` a consumer. Seven species carry it, every one of them `biomes: ["underworld"]`, which the engine cannot draw, so they were authored, published and unreachable. They stay unplaceable on purpose: you do not encounter a thing that crossed, you find what it left. That is what `placement: "lore"` was for, and the midden is where the city puts it.

Two questions rather than one, because a map about a supernatural door has to be clear about what is actually destroying the place. The gate gets swept; the sea gets a new wall; only one of those finishes Dwarka and it is not the interesting one. The unsound reading of that question is the one the whole map has spent its time making attractive, which is the point.

Pell will not leave, for the opposite reason to Bekh: not that somebody has to stay, but that the work does not end and that is not an argument for stopping. He sweeps an interdimensional gate as municipal maintenance, which is the tone the whole map is written in.

Six places, six discoveries, two questions, two people, two Kia words. Index 1.4.0 -> 1.5.0. Lint and playability pass; finishable alone, 6 of 6.