### PR TITLE
The Dry Harbour: a place that is out of date rather than mysterious

### DIFF
--- a/database/discoveries/discovery_channel_gravel.json
+++ b/database/discoveries/discovery_channel_gravel.json
@@ -1,0 +1,44 @@
+{
+  "id": "discovery_channel_gravel",
+  "type": "discovery",
+  "name": "How the Stones Are Lying",
+  "discipline": "geography",
+  "found_at": [
+    "poi_fossil_channel"
+  ],
+  "levels": [
+    {
+      "entry": "A valley shaped like a river. That shape can be made by other things and I should not assume."
+    },
+    {
+      "entry": "The gravel is rounded — carried, not fallen — and it grades from fine at the edges to coarse in the middle."
+    },
+    {
+      "entry": "That grading is a current, and a strong one. Nothing seasonal sorts stones like this."
+    },
+    {
+      "entry": "In low sun the terraces show along both walls: three of them, cut at three levels, so it ran high for a long time and then lower for a long time.",
+      "conditions": {
+        "time_of_day": [
+          "dawn",
+          "evening"
+        ]
+      }
+    },
+    {
+      "entry": "But no fourth terrace, and no delta of silt at the mouth. A river that dries slowly leaves both. This one was running one year and gone the next."
+    }
+  ],
+  "answers": [
+    "question_where_the_water_went"
+  ],
+  "notes": "The geography discovery and the strongest evidence for suddenness -- expressed as an absence, which is the discipline's real skill.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_glass_scar.json
+++ b/database/discoveries/discovery_glass_scar.json
@@ -1,0 +1,43 @@
+{
+  "id": "discovery_glass_scar",
+  "type": "discovery",
+  "name": "A Line of Glass",
+  "discipline": "anomalies",
+  "found_at": [
+    "poi_glass_scar"
+  ],
+  "levels": [
+    {
+      "entry": "A seam of green-black glass running straight across open sand. Nothing near it is scorched."
+    },
+    {
+      "entry": "Fused sand, and only at the surface — a hand down it is ordinary. Whatever did this was fast enough that the heat never travelled."
+    },
+    {
+      "entry": "It runs true for as far as I walked it, which was most of a morning, and it does not deviate for a dune or a ridge.",
+      "conditions": {
+        "weather": [
+          "clear"
+        ]
+      }
+    },
+    {
+      "entry": "It crosses the fossil channel without a break, and the channel gravel underneath it is unfused. So it happened after the water went, and not long after.",
+      "requires": [
+        "discovery_channel_gravel"
+      ]
+    },
+    {
+      "entry": "I can date it and describe it and I cannot say what it is. I have written down the bearing, which is the only useful thing I have."
+    }
+  ],
+  "notes": "Deliberately unresolved, like the Cloud Stair. Its job is to date the ending, not to explain it, and the diary says so.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_mooring_rings.json
+++ b/database/discoveries/discovery_mooring_rings.json
@@ -1,0 +1,42 @@
+{
+  "id": "discovery_mooring_rings",
+  "type": "discovery",
+  "name": "The Rings Are the Right Height",
+  "discipline": "archaeology",
+  "found_at": [
+    "poi_mooring_stones",
+    "poi_customs_house"
+  ],
+  "levels": [
+    {
+      "entry": "Iron rings set into a stone wall in the desert. Somebody's idea of a joke, or a ruin from a wetter age I have no date for."
+    },
+    {
+      "entry": "They are mooring rings. The wear is on the inner face, one side only, the way a rope pulls when a hull rides at anchor."
+    },
+    {
+      "entry": "Set at three heights along the wall, which is a tide, and the spacing between them is about a forearm."
+    },
+    {
+      "entry": "A forearm of tide means this was open water with a sea connection, not a lake. And the rings are sized for a hull I have seen at Dwarka."
+    },
+    {
+      "entry": "The iron has pitted but not parted. Four hundred years in dry air would do about this. Not four thousand.",
+      "requires": [
+        "discovery_tariff_boards"
+      ]
+    }
+  ],
+  "answers": [
+    "question_where_the_water_went"
+  ],
+  "notes": "The map's opening image, argued rather than asserted. The last rung is the first hint that this is recent, which is the whole thesis.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_road_follows_water.json
+++ b/database/discoveries/discovery_road_follows_water.json
@@ -1,0 +1,38 @@
+{
+  "id": "discovery_road_follows_water",
+  "type": "discovery",
+  "name": "The Road Still Goes the Long Way",
+  "discipline": "archaeology",
+  "found_at": [
+    "poi_caravan_camp"
+  ],
+  "levels": [
+    {
+      "entry": "The caravan road bends north here for no reason I can see, and adds half a day."
+    },
+    {
+      "entry": "Everyone stops at the same ground, which is exposed, far from the well, and inconvenient."
+    },
+    {
+      "entry": "Laid over the fossil channel, the bend is not a bend. The road is following a bank."
+    },
+    {
+      "entry": "The camp is at a crossing. There is nothing to cross, and the caravans still stop where the ford was, because that is where you stop."
+    },
+    {
+      "entry": "Nobody chose to keep doing this. The road is older than any of them and it remembers something none of them do.",
+      "requires": [
+        "discovery_channel_gravel"
+      ]
+    }
+  ],
+  "notes": "The map's quietest discovery and possibly its best: habit outliving the reason for it, with nobody at fault.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_tariff_boards.json
+++ b/database/discoveries/discovery_tariff_boards.json
@@ -1,0 +1,44 @@
+{
+  "id": "discovery_tariff_boards",
+  "type": "discovery",
+  "name": "What the Customs House Was Counting",
+  "discipline": "linguistics",
+  "found_at": [
+    "poi_customs_house"
+  ],
+  "levels": [
+    {
+      "entry": "Boards fixed to the wall of the weighing floor, cut with rows of marks. A tally of something."
+    },
+    {
+      "entry": "Two columns. The left is quantities and the right is a rate — this is a tariff, posted where the payer could see it."
+    },
+    {
+      "entry": "The goods are named in a trade shorthand. Grain, oil, salt, and one I cannot read at all, which is charged at nine times the rate of salt.",
+      "requires": [
+        "word_sarv_tolu"
+      ]
+    },
+    {
+      "entry": "Tolu. Teshk uses the word for the shallow water at the head of a channel — so the ninefold rate was on something that only came in on a shallow draught."
+    },
+    {
+      "entry": "The last board is unfinished. Ruled, and the first two rows cut, and then nothing — which is not what abandonment looks like. Somebody stopped in the middle of a morning."
+    }
+  ],
+  "answers": [
+    "question_where_the_water_went"
+  ],
+  "helps": [
+    "npc_ravi"
+  ],
+  "notes": "The map's clock. An unfinished tariff board dates the ending to a day rather than a century, which is what makes the sudden reading arguable.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_thorn_roots.json
+++ b/database/discoveries/discovery_thorn_roots.json
@@ -1,0 +1,38 @@
+{
+  "id": "discovery_thorn_roots",
+  "type": "discovery",
+  "name": "A Tree Drinking From a River That Left",
+  "discipline": "botany",
+  "found_at": [
+    "poi_last_well"
+  ],
+  "levels": [
+    {
+      "entry": "Thorn trees along the old channel, alive, in ground that has had no rain worth the name this year."
+    },
+    {
+      "entry": "They are not doing it on rain. Something is reaching water and it is not the surface."
+    },
+    {
+      "entry": "A washout has opened one root system. It goes down past where I can follow, straight, with no side branching at all."
+    },
+    {
+      "entry": "No side roots means no water to find on the way. This tree is drinking from the depth the wells reach, and it is a slower version of the same argument."
+    },
+    {
+      "entry": "The young ones are dying and the old ones are not. Whatever the root has to reach, it became too far to reach for a seedling somewhere inside a human lifetime."
+    }
+  ],
+  "helps": [
+    "npc_teshk"
+  ],
+  "notes": "Botany doing the same dating work as the wells, from the other side. The detail that only the young die is the whole point.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/discoveries/discovery_well_depth.json
+++ b/database/discoveries/discovery_well_depth.json
@@ -1,0 +1,44 @@
+{
+  "id": "discovery_well_depth",
+  "type": "discovery",
+  "name": "Why There Is Only One Well",
+  "discipline": "geography",
+  "found_at": [
+    "poi_last_well"
+  ],
+  "levels": [
+    {
+      "entry": "Forty families and one well. I assumed poverty. Teshk says three others were dug and all three are dry."
+    },
+    {
+      "entry": "The dry ones are shallower. Not much — a few armspans — but all three of them, and this one is not."
+    },
+    {
+      "entry": "So the water is not gone, it is lower, and it is lowering. The rope has been lengthened twice in Teshk's lifetime."
+    },
+    {
+      "entry": "Which gives a rate, and the rate gives a date. Two more lengthenings and this well joins the other three.",
+      "requires": [
+        "discovery_channel_gravel"
+      ]
+    }
+  ],
+  "answers": [
+    "question_where_the_water_went"
+  ],
+  "helps": [
+    "npc_teshk"
+  ],
+  "restores": [
+    "poi_last_well"
+  ],
+  "notes": "Turns the map's history into the inhabitants' future. The only discovery here with a deadline attached.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/field_maps/field_map_dry_harbour.json
+++ b/database/field_maps/field_map_dry_harbour.json
@@ -1,0 +1,40 @@
+{
+  "id": "field_map_dry_harbour",
+  "type": "field_map",
+  "name": "The Dry Harbour",
+  "region": "region_gedrosian_desert",
+  "seed_biomes": [
+    "desert",
+    "plains",
+    "settlement",
+    "hills"
+  ],
+  "scale": "large",
+  "points_of_interest": [
+    "poi_mooring_stones",
+    "poi_customs_house",
+    "poi_last_well",
+    "poi_fossil_channel",
+    "poi_caravan_camp",
+    "poi_glass_scar"
+  ],
+  "neighbours": [
+    "field_map_narmada"
+  ],
+  "climate": {
+    "clear": 80,
+    "storm": 11,
+    "mist": 5,
+    "rain": 4
+  },
+  "arrival": "The harbour wall runs for four hundred paces and the mooring rings are still in it, at the height a loaded hull would sit. There is no water. There has been no water for long enough that the nearest is two days' walk, and short enough that the rings have not rusted through.",
+  "notes": "Fourth field map, and the one about time rather than about knowing. Everything here was built or evolved for a wetter world that ended inside cultural memory, and nothing about it is mysterious -- it is all simply out of date. First map where canon's own species populate the ground: forty Gedrosian species, all placeable.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/field_maps/field_map_narmada.json
+++ b/database/field_maps/field_map_narmada.json
@@ -19,6 +19,7 @@
     "poi_cloud_stair"
   ],
   "neighbours": [
+    "field_map_dry_harbour",
     "field_map_lothal"
   ],
   "arrival": "The road up the scarp is the only part of the plateau anyone built. Everything above it was already here: black rock in steps a hundred feet high, holding a flat green country the sea never reached. They will tell you at the top that this is why the University is here. They are right, and it is not the whole reason.",

--- a/database/field_questions/question_where_the_water_went.json
+++ b/database/field_questions/question_where_the_water_went.json
@@ -1,0 +1,54 @@
+{
+  "id": "question_where_the_water_went",
+  "type": "field_question",
+  "question": "There is a harbour here and no sea, a road that follows a bank that is not there, and forty families lengthening a rope. I would like to know whether this place is dying or whether it already died and this is the noise afterwards.",
+  "discipline": "geography",
+  "raised_at": "poi_mooring_stones",
+  "raised_by": "npc_ravi",
+  "evidence": [
+    "discovery_mooring_rings",
+    "discovery_channel_gravel",
+    "discovery_tariff_boards"
+  ],
+  "resolutions": [
+    {
+      "conclusion": "Aridification, over the age it takes a climate to turn. The harbour is simply very old.",
+      "requires": [
+        "discovery_mooring_rings"
+      ],
+      "sound": false,
+      "revisit": "The iron has pitted and not parted, and the last tariff board was ruled and abandoned in the middle of a morning. Neither of those is an age.",
+      "revisit_after": "discovery_tariff_boards"
+    },
+    {
+      "conclusion": "The sea withdrew and the river followed it out, the way a coast retreats.",
+      "requires": [
+        "discovery_mooring_rings",
+        "discovery_channel_gravel"
+      ],
+      "sound": false,
+      "revisit": "A river leaving slowly cuts a fourth terrace and drops a silt fan at its mouth. There is no fourth terrace and there is no fan.",
+      "revisit_after": "discovery_channel_gravel"
+    },
+    {
+      "conclusion": "It was taken, in about a year, and everything here is what a place does afterwards: the road keeps the old bend, the trees keep the old depth, and the rope gets longer.",
+      "requires": [
+        "discovery_mooring_rings",
+        "discovery_channel_gravel",
+        "discovery_tariff_boards"
+      ],
+      "sound": true
+    }
+  ],
+  "local_knowledge": "Ravi's family kept the customs house through four generations of no customs. He will tell you the water was taken, and he means it plainly and without blame — the way you would say a roof came off.",
+  "academic_hypothesis": "The Narmada position is that the Gedrosian has been arid throughout the archive's period and that the harbour is pre-Shattering, on the grounds that no post-Shattering settlement could have been that wealthy. The reasoning rests entirely on the second clause.",
+  "notes": "The map's question, and the one where the academy's error is snobbery rather than method -- it cannot picture a rich town out here, so it dates the town instead of checking the iron.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/index.json
+++ b/database/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "SouthOfTethys canonical entity index",
   "counts": {
     "characters": 41,
@@ -11,12 +11,12 @@
     "artifacts": 3,
     "factions": 3,
     "mythology": 3,
-    "field_maps": 3,
-    "points_of_interest": 18,
-    "discoveries": 24,
-    "field_questions": 7,
-    "npcs": 8,
-    "vocabulary": 8
+    "field_maps": 4,
+    "points_of_interest": 24,
+    "discoveries": 31,
+    "field_questions": 8,
+    "npcs": 10,
+    "vocabulary": 10
   },
   "entities": {
     "characters": [
@@ -455,6 +455,7 @@
       "mythology_varuna"
     ],
     "field_maps": [
+      "field_map_dry_harbour",
       "field_map_dwarka",
       "field_map_lothal",
       "field_map_narmada"
@@ -462,16 +463,22 @@
     "points_of_interest": [
       "poi_basalt_quarry",
       "poi_bone_midden",
+      "poi_caravan_camp",
       "poi_cloud_stair",
+      "poi_customs_house",
       "poi_drowned_dockyard",
       "poi_drowned_seawall",
       "poi_eastern_field",
+      "poi_fossil_channel",
       "poi_gate_court",
+      "poi_glass_scar",
       "poi_herders_terraces",
       "poi_kavik_tower",
+      "poi_last_well",
       "poi_long_archive",
       "poi_lothal_camp",
       "poi_marsh_shrine",
+      "poi_mooring_stones",
       "poi_narmada_university",
       "poi_salt_orchard",
       "poi_silted_granary",
@@ -482,6 +489,7 @@
     "discoveries": [
       "discovery_archive_baseline",
       "discovery_bitter_millet",
+      "discovery_channel_gravel",
       "discovery_cloud_stair",
       "discovery_dockyard_reef",
       "discovery_double_classified",
@@ -489,20 +497,26 @@
       "discovery_fever_root_spread",
       "discovery_gate_rhythm",
       "discovery_ghost_mangrove_channel",
+      "discovery_glass_scar",
       "discovery_market_ledger",
       "discovery_marsh_lurker_habits",
       "discovery_mask_niche",
       "discovery_midden_layers",
+      "discovery_mooring_rings",
       "discovery_moving_spring",
       "discovery_poisoned_ground",
       "discovery_quarry_sequence",
       "discovery_red_rice_survival",
+      "discovery_road_follows_water",
       "discovery_saltreed_thatch",
       "discovery_seawall_courses",
       "discovery_silver_water",
+      "discovery_tariff_boards",
       "discovery_terrace_script",
       "discovery_terrace_water",
+      "discovery_thorn_roots",
       "discovery_tower_collapse",
+      "discovery_well_depth",
       "discovery_wrong_anatomy"
     ],
     "field_questions": [
@@ -512,14 +526,17 @@
       "question_terrace_purpose",
       "question_two_names",
       "question_what_comes_through",
-      "question_what_ends_dwarka"
+      "question_what_ends_dwarka",
+      "question_where_the_water_went"
     ],
     "npcs": [
       "npc_bekh",
       "npc_marn",
       "npc_okhi",
       "npc_pell",
+      "npc_ravi",
       "npc_sura",
+      "npc_teshk",
       "npc_thrali",
       "npc_uma",
       "npc_vessa"
@@ -532,7 +549,9 @@
       "word_kia_vaath",
       "word_maru_anu",
       "word_maru_khet",
-      "word_maru_sev"
+      "word_maru_sev",
+      "word_sarv_khenu",
+      "word_sarv_tolu"
     ]
   }
 }

--- a/database/npcs/npc_ravi.json
+++ b/database/npcs/npc_ravi.json
@@ -1,0 +1,49 @@
+{
+  "id": "npc_ravi",
+  "type": "npc",
+  "name": "Ravi",
+  "role": "keeper of the customs house",
+  "found_at": [
+    "poi_customs_house",
+    "poi_last_well"
+  ],
+  "language": "sarv",
+  "would_settle": true,
+  "knows": [
+    "discovery_tariff_boards",
+    "discovery_mooring_rings",
+    "question_where_the_water_went"
+  ],
+  "lines": [
+    {
+      "text": "My family has kept this building for four generations and there has been nothing to keep it for during any of them. You are the first person to ask what the boards say.",
+      "gives": [
+        "question_where_the_water_went"
+      ]
+    },
+    {
+      "text": "Tolu. It is not a good, it is a draught — the shallow water at the head of a channel. Whatever came in on it, we taxed at nine times salt and I do not know what it was.",
+      "requires": [
+        "discovery_mooring_rings"
+      ],
+      "gives": [
+        "word_sarv_tolu"
+      ]
+    },
+    {
+      "text": "The last board is not finished. I have known that since I was a boy and I have never once wondered about it until you stood there wondering out loud.",
+      "requires": [
+        "discovery_tariff_boards"
+      ]
+    }
+  ],
+  "notes": "Four generations of custody with nothing to be custodian of. Would settle -- the building is a duty, not a home, and he has never been asked to do anything else.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/npcs/npc_teshk.json
+++ b/database/npcs/npc_teshk.json
@@ -1,0 +1,45 @@
+{
+  "id": "npc_teshk",
+  "type": "npc",
+  "name": "Teshk",
+  "role": "well-keeper",
+  "found_at": [
+    "poi_last_well",
+    "poi_caravan_camp"
+  ],
+  "language": "sarv",
+  "would_settle": false,
+  "knows": [
+    "discovery_well_depth",
+    "discovery_thorn_roots"
+  ],
+  "lines": [
+    {
+      "text": "Three wells were dug before this one and all three are dry. People say we were unlucky in where we put them. We were not unlucky in where. We were unlucky in when.",
+      "gives": [
+        "word_sarv_khenu"
+      ]
+    },
+    {
+      "text": "The rope has been lengthened twice since I was small. I did the second one. I expect to do a third and I do not expect to do a fourth.",
+      "requires": [
+        "discovery_well_depth"
+      ]
+    },
+    {
+      "text": "No. Forty families work this rope and it takes two. If I go, it takes two of somebody else, and there are not two of somebody else to spare.",
+      "requires": [
+        "discovery_thorn_roots"
+      ]
+    }
+  ],
+  "notes": "Will not leave, and for a third distinct reason: not duty like Bekh, not unfinished work like Pell, but arithmetic -- the rope needs two people and there are not two to spare.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_caravan_camp.json
+++ b/database/points_of_interest/poi_caravan_camp.json
@@ -1,0 +1,28 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dry_harbour",
+  "id": "poi_caravan_camp",
+  "name": "The Caravan Ground",
+  "kind": "travel_node",
+  "terrain": [
+    "desert",
+    "plains"
+  ],
+  "discoveries": [
+    "discovery_road_follows_water"
+  ],
+  "npcs": [
+    "npc_teshk"
+  ],
+  "description": "Where the road stops for the night, and has for longer than the road has made sense.",
+  "arrival": "The camp is on the wrong side of the ridge for shelter and the wrong distance from the well, and every caravan stops here anyway, because this is where you stop.",
+  "notes": "The road is the map's other clock: it still follows a river that is not there.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_customs_house.json
+++ b/database/points_of_interest/poi_customs_house.json
@@ -1,0 +1,44 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dry_harbour",
+  "id": "poi_customs_house",
+  "name": "The Customs House",
+  "kind": "archaeological_site",
+  "terrain": [
+    "settlement",
+    "desert"
+  ],
+  "discoveries": [
+    "discovery_tariff_boards",
+    "discovery_mooring_rings"
+  ],
+  "npcs": [
+    "npc_ravi"
+  ],
+  "sub_locations": [
+    {
+      "id": "weighing_floor",
+      "name": "The Weighing Floor",
+      "description": "Sunk a hand below the doorway so a spilled load could be swept back. The sweep marks are still there, going the same way every time."
+    },
+    {
+      "id": "the_strongroom",
+      "name": "The Strongroom",
+      "description": "Barrel-vaulted, no window, and the door frame is worn at the height of a shoulder rather than a hand — people came out of it carrying.",
+      "requires": [
+        "discovery_tariff_boards"
+      ]
+    }
+  ],
+  "description": "A building for taxing cargo that stopped arriving.",
+  "arrival": "It is the best-built thing for sixty miles, because it was the building that made money, and it is intact because nobody has had any reason to take it apart.",
+  "notes": "Where the archaeology and the linguistics meet. The tariff boards are the map's clock.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_fossil_channel.json
+++ b/database/points_of_interest/poi_fossil_channel.json
@@ -1,0 +1,25 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dry_harbour",
+  "id": "poi_fossil_channel",
+  "name": "The Fossil Channel",
+  "kind": "wilderness",
+  "terrain": [
+    "desert",
+    "hills"
+  ],
+  "discoveries": [
+    "discovery_channel_gravel"
+  ],
+  "description": "A river-shaped valley with gravel in it, sorted the way running water sorts gravel.",
+  "arrival": "From the ridge it is unmistakably a river and from inside it is a valley with stones in it. The stones are the argument: rounded, graded fine to coarse across the width, and lying exactly as a current would leave them.",
+  "notes": "The geography discovery. The sorting is what makes it evidence rather than a shape someone imagined.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_glass_scar.json
+++ b/database/points_of_interest/poi_glass_scar.json
@@ -1,0 +1,24 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dry_harbour",
+  "id": "poi_glass_scar",
+  "name": "The Glass Scar",
+  "kind": "anomaly",
+  "terrain": [
+    "desert"
+  ],
+  "discoveries": [
+    "discovery_glass_scar"
+  ],
+  "description": "A seam of fused sand, running straight, where nothing should have been hot enough.",
+  "arrival": "Green-black glass, in a line you could follow at a walk, and under it sand that was never heated at all. Whatever did this did it fast enough that the heat had no time to go downwards.",
+  "notes": "The anomaly, and the map's only unexplained thing. Kept small and undramatic: it is a date stamp more than a mystery.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_last_well.json
+++ b/database/points_of_interest/poi_last_well.json
@@ -1,0 +1,30 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dry_harbour",
+  "id": "poi_last_well",
+  "name": "The Last Well",
+  "kind": "settlement",
+  "terrain": [
+    "settlement",
+    "desert"
+  ],
+  "discoveries": [
+    "discovery_well_depth",
+    "discovery_thorn_roots"
+  ],
+  "npcs": [
+    "npc_ravi",
+    "npc_teshk"
+  ],
+  "description": "The one well still reaching water, and the reason anybody is still here.",
+  "arrival": "Forty families, one well, and a rope long enough that two people are needed to work it. Nobody has drilled a second. Teshk will tell you why, and the answer is not money.",
+  "notes": "The people. The well is the map's whole economy and its countdown.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/points_of_interest/poi_mooring_stones.json
+++ b/database/points_of_interest/poi_mooring_stones.json
@@ -1,0 +1,25 @@
+{
+  "type": "point_of_interest",
+  "field_map": "field_map_dry_harbour",
+  "id": "poi_mooring_stones",
+  "name": "The Mooring Stones",
+  "kind": "archaeological_site",
+  "terrain": [
+    "desert",
+    "plains"
+  ],
+  "discoveries": [
+    "discovery_mooring_rings"
+  ],
+  "description": "Four hundred paces of harbour wall, with the rings still in it.",
+  "arrival": "You can put your hand through a mooring ring and feel where a rope wore it thin on one side only, which tells you the current ran that way, which tells you there was a current.",
+  "notes": "The image the map exists for. Deliberately the first place a player is likely to reach.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/regions/region_gedrosian_desert.json
+++ b/database/regions/region_gedrosian_desert.json
@@ -5,9 +5,11 @@
   "continent": "jambhudweepa",
   "bestiary_region": "gedrosian-taklamakan",
   "biomes": [
-    "desert"
+    "desert",
+    "plains",
+    "hills"
   ],
-  "notes": "Arid frontier. Home to Beedu desert rays and northern steppe approaches.",
+  "notes": "Arid interior, and young: the harbour, the fossil channel and the caravan road all date the water's departure to within cultural memory rather than to geological time. Forty authored species, all desert-placeable.",
   "canon": "primary",
   "sources": [
     "map"

--- a/database/vocabulary/word_sarv_khenu.json
+++ b/database/vocabulary/word_sarv_khenu.json
@@ -1,0 +1,20 @@
+{
+  "type": "vocabulary",
+  "language": "sarv",
+  "id": "word_sarv_khenu",
+  "word": "khenu",
+  "gloss": "unlucky in when rather than where",
+  "literal": "wrong-year",
+  "learned_from": [
+    "npc_teshk"
+  ],
+  "notes": "A whole grammar of hindsight in one word, in a language spoken by people who have needed it. The Kia have no equivalent and the University would need a sentence.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}

--- a/database/vocabulary/word_sarv_tolu.json
+++ b/database/vocabulary/word_sarv_tolu.json
@@ -1,0 +1,20 @@
+{
+  "type": "vocabulary",
+  "language": "sarv",
+  "id": "word_sarv_tolu",
+  "word": "tolu",
+  "gloss": "the shallow head of a channel",
+  "literal": "where the keel touches",
+  "learned_from": [
+    "npc_ravi"
+  ],
+  "notes": "A draught rather than a place, which is why it reads as a good on a tariff board until somebody who still uses the word explains it.",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design",
+    "AI_CONTEXT.md"
+  ]
+}


### PR DESCRIPTION
The fourth field map, and the first about time rather than about knowing. Lothal teaches looking; Narmada shows an institution whose record begins at the wound; Dwarka is where the locals are simply right. Here everything -- a harbour wall with the mooring rings still in it, a road that bends for a bank that is not there, thorn trees drinking at a depth their own seedlings cannot reach -- was built or evolved for a wetter world that ended inside living memory.

The academy's error is snobbery rather than method this time. It dates the harbour to before the Shattering because it cannot picture a town that rich out here, and the whole argument rests on that clause rather than on the iron, which has pitted and not parted.

Teshk will not leave, for a third distinct reason: not duty like Bekh, not unfinished work like Pell, but arithmetic -- the rope needs two people and there are not two to spare.

First map where canon's own species populate the ground. Forty Gedrosian species already exist, all `biomes: ["desert"]` and placeable, so it fills itself. It is also the map the per-region climate work was for: under the old single hardcoded sky it would have rained here in a fifth of all spells.

region_gedrosian_desert had no biomes recorded at all, which is why nothing could be laid out in it. Six places, seven discoveries, one question, two people, two words in a third language. Index 1.5.0 -> 1.6.0; finishable alone, 7 of 7.