### PR TITLE
A search endpoint, and a label for everything it can return

### DIFF
--- a/services/api/main.py
+++ b/services/api/main.py
@@ -327,6 +327,35 @@ def lore(place: Place) -> dict:
     return {"query": query, "sources": sources(hits)}
 
 
+class Question(BaseModel):
+    """A question in the player's own words, rather than a tile."""
+
+    query: str
+    k: int = 5
+
+
+@app.post("/search")
+def search(question: Question) -> dict:
+    """
+    Retrieval over the whole corpus, for a question nobody wrote a tile for.
+
+    `/lore` answers "what does canon say about where I am standing", which is the shape the
+    game needed first and is useless for "has anything like this been seen before". This takes
+    words instead of coordinates.
+
+    Public and retrieval-only, exactly like `/lore`: it runs no model, spends nothing, and
+    returns which canon entities are nearest rather than prose about them. Generation stays
+    behind `/ask` and its key.
+    """
+    query = (question.query or "").strip()
+    if not query:
+        return {"query": "", "sources": []}
+    # Bounded rather than trusted: k comes from a client and a large one is a cheap way to
+    # make the service do real work on somebody else's behalf.
+    hits = vidur.retrieve(query, k=max(1, min(question.k, 20)))
+    return {"query": query, "sources": sources(hits)}
+
+
 @app.post("/ask")
 def ask(place: Place, x_canon_key: str | None = Header(default=None)) -> dict:
     """A written passage about this tile, grounded in the canon that was retrieved."""

--- a/services/chroma/index_chroma_service.py
+++ b/services/chroma/index_chroma_service.py
@@ -236,8 +236,18 @@ def build_metadata(repo_root: Path, fpath: Path, payload: dict | None, chunk_ind
         eid = payload.get("id") or fpath.stem
         meta["entity_id"] = eid
         meta["entity_type"] = payload.get("type") or fpath.parent.name.rstrip("s")
-        if payload.get("name"):
-            meta["name"] = payload["name"]
+        # Every entity needs something a human can be shown. Vocabulary carries `word` and a
+        # field question carries `question`, and neither has a `name` -- so a search that
+        # matched one returned a result labelled `None`, which is how this was found.
+        label = (
+            payload.get("name")
+            or payload.get("title")
+            or payload.get("word")
+            or payload.get("question")
+        )
+        if label:
+            # A question is a paragraph; a label is not. First sentence, and no longer.
+            meta["name"] = label if len(label) < 90 else label[:87].rsplit(" ", 1)[0] + "..."
         if payload.get("title"):
             meta["title"] = payload["title"]
         if payload.get("epoch"):


### PR DESCRIPTION
/lore answers "what does canon say about where I am standing", which was the shape the game needed first and is useless for "has anything like this been seen before". /search takes words instead of coordinates. Public and retrieval-only like /lore: no model, nothing spent, and it returns which entities are nearest rather than prose about them. k is clamped, because a large one from a client is a cheap way to make the service work on somebody else's behalf.

Using it immediately found a gap. A hit on a vocabulary entry came back labelled `None`: `build_metadata` took `name` or `title`, and vocabulary carries `word` while a field question carries `question` -- so two entity types had been indexed without anything a human could be shown for the whole time retrieval has existed. Both have labels now, questions truncated at a sentence's worth, and exactly one record is still unlabelled: `index.json`, which is not an entity.

Verified against the real index: "a harbour with no water" returns the Drowned Dockyard, and "a door that opens in the mist" now says vaath rather than None.