### PR TITLE
Documentation that matches the repository

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,67 +1,71 @@
-# GitHub Copilot Instructions for SouthOfTethys
+# Working in SouthOfTethys
 
-## Project Overview
-- **SouthOfTethys** is a procedurally evolving storytelling engine inspired by world simulation games (e.g., Dwarf Fortress).
-- All world data is stored in JSON and Markdown files, version-controlled in Git.
-- Python scripts in `utils/` automate worldbuilding, event tracking, genealogy, and species evolution.
+This file was describing a repository that no longer exists — `timeline/timeline.json`,
+`characters/`, `flora_fauna/`, `locations/`, an Ollama extraction step — all of which were
+replaced by `database/` some time ago. Anything it said before this rewrite should be treated
+as wrong.
 
-## Architecture & Data Flow
-- **Timeline**: All events are tracked in `timeline/timeline.json`, sorted by fantasy date (e.g., "Act 1, Scene 2").
-- **Characters**: Each character has a `.json` or `.md` file in `characters/`, with genealogy tracked in `characters/genealogy.json`.
-- **Species**: Flora/fauna profiles and evolution chains are in `flora_fauna/`.
-- **Locations**: World regions and connections are described in `cartography/overworld.json` and `locations/`.
-- **Art**: Referenced by filename only, not embedded.
-- **Scripts**: Key Python tools include:
-  - `generate_timeline.py`: Sorts and summarizes timeline events.
-  - `lint_story.py`: Validates consistency, date formats, and cross-references (characters/species).
-  - `generate_timeline_mermaid.py`: Outputs a pictorial timeline as Mermaid graph.
-  - `evolve_species.py`: Simulates species mutation based on events.
-  - `snippet_processor.py`: Uses LLMs (Ollama) to extract structured data from story snippets.
+## What this repository is
 
-## Developer Workflows
-- **Build & Validate**:
-  - Use Docker (`Dockerfile`, `compose.yaml`) for reproducible builds and script execution.
-  - Run `python utils/lint_story.py` to check for broken or inconsistent story data before commits.
-  - CI/CD pipelines (`.github/workflows/ci.yml`, `story-validation.yml`) run linting, timeline generation, and publish artifacts on push/PR to `main` and `feature/*` branches.
-- **Pre-commit Hook**:
-  - `.git/hooks/pre-commit` runs auto-formatting (autopep8, autoflake) and flake8 linting before allowing commits.
-- **Debugging**:
-  - Use VS Code's Docker debug tasks (`.vscode/launch.json`, `compose.debug.yaml`) for step-through debugging in containers.
+The **canon** half of a two-repository project. It owns what exists and what is true. The other
+repository, `4000BCESaraswathy`, is a browser game that owns what a particular player did and
+how it looks. The split holds because everything canon holds is a *noun* — places, species,
+discoveries, people, words — and everything the game holds is a *verb* or a *view*.
 
-## Project-Specific Conventions
-- **Fantasy Date Format**: All events use "Act X, Scene Y" format; scripts expect this for sorting and validation.
-- **Metadata**: Keys are case-sensitive; art is referenced by filename only.
-- **Consistency**: All updates must maintain world consistency; cross-file references (e.g., character/species in events) are validated by scripts.
-- **Modular Python**: Scripts are organized for single-responsibility and composability.
+Everything canonical lives in `database/` as one JSON file per entity, validated against JSON
+Schema. Index at `database/index.json`, currently **v1.6.0, 504 entities**:
 
-## Integration Points
-- **AI Model (Hugging Face)**: `snippet_processor.py` now uses our own Hugging Face model (`lordlebu/4000BCSaraswaty`) to extract structured data from story snippets, accessible via the Vidur Portal web app.
-- **Artifacts**: Timeline visualizations and world maps are published as build artifacts in CI.
+| | |
+|---|---|
+| **Species** | 256 fauna, 90 flora |
+| **World** | 7 regions, 2 settlements, 41 characters, 12 events, 3 factions, 3 artifacts, 3 mythology |
+| **Field diary** | 4 field maps, 24 points of interest, 31 discoveries, 8 field questions, 10 NPCs, 10 vocabulary |
 
-## Examples
-- To add a new event: update `timeline/timeline.json` and run `generate_timeline.py` and `lint_story.py`.
-- To add a new character: create a `.json` in `characters/`, update genealogy if needed, and validate with `lint_story.py`.
-- To process a story snippet: use the Vidur Portal web app (uses our Hugging Face AI model).
+## The commands that matter
 
-## Key Files & Directories
-- `timeline/timeline.json`
-- `characters/`
-- `flora_fauna/`
-- `cartography/overworld.json`
-- `utils/`
-- `.github/workflows/`
-- `.vscode/`
-- `Dockerfile`
-- `compose.yaml`
-- `CONTEXT.md`
----
-**For AI agents:**
-- Always validate cross-references and formats using provided scripts before committing or merging.
-- Prefer updating or generating Markdown summaries for documentation.
-- Use the fantasy date format and maintain consistency across all world data.
+```bash
+python utils/lint_story.py          # schemas, index counts, every cross-reference resolves
+python utils/check_playability.py   # can a player actually reach it all — see below
+python utils/export_canon_bundle.py --apply   # write the game's data/canon/ bundle
+```
 
-name: Upload merged timeline artifact
-uses: actions/upload-artifact@v4
-with:
-  name: full_timeline
-  path: timeline/timeline.json
+The first two run in CI on every push (`.github/workflows/story-validation.yml`) and must pass
+before anything merges.
+
+**`check_playability.py` is a simulation, not a set check.** It starts from nothing and
+repeatedly does whatever has become possible — climb a rung, hear a line, take a word — until
+nothing more opens. Asking instead whether each requirement is "obtainable somewhere" passes a
+cycle: A's last rung needs B, B's last rung needs A, both obtainable, neither ever first. That
+shipped once. It deliberately duplicates two rules from the game's `src/journey.ts`; if the
+semantics change in one, change them in both.
+
+## Rules that are not negotiable
+
+- **Canon exports canon's own shape.** The game owns adapters that translate it. Do not shape a
+  schema around a TypeScript interface in another repository.
+- **Never edit the game's `data/canon/`.** It is generated. Change the entity here and re-export.
+- **Array order is part of the seed contract.** The game indexes into per-biome lists, so
+  entities carry `source_index` and unindexed ones sort last — additions cannot reshuffle a
+  world somebody already walked.
+- **Work on feature branches.** Never commit to `main`.
+- **Merging canon redeploys the retrieval service** (`deploy-canon-service.yml`), which rebuilds
+  the search index and then checks the live one covers canon.
+
+## Where the reasoning is written down
+
+- `docs/decisions.md` — every call made on the project's behalf and why, plus what is still
+  open. Read this before changing anything structural.
+- `database/TODO.md` — which entities are missing.
+- `DESIGN.md` — the rulings that govern authoring, including the era and how field maps work.
+- `CLAUDE.md` — the same ground as this file, for agents that read that name instead.
+
+## Authoring a field map, if that is the task
+
+Six points of interest, six to nine discoveries of three to seven rungs, one to three field
+questions, two or three people, and roughly 1,700 words of prose. The typing is not the
+constraint — each map needs a *thesis* that is not a repeat of another's, and the four that
+exist have used: learning to look, an archive whose record begins at the wound, a place where
+local knowledge is simply right, and a place that is out of date rather than mysterious.
+
+Only regions whose biomes are `renderable` in `database/biomes.json` can hold a map. The
+Tethys Sky Routes cannot until sky biomes can be drawn.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## What this is
+
+The **canon** half of a two-repository project. This repository owns *what exists and what is
+true*. The sibling, `4000BCESaraswathy`, is a browser game that owns *what a particular player
+did and how it looks*.
+
+That division settles nearly every question that comes up: everything canon holds is a **noun**
+— places, species, discoveries, people, words — and everything the game holds is a **verb** or a
+**view** — walking, observing, rendering, saving. When something new appears, apply that test
+rather than debating it.
+
+Canon is one JSON file per entity under `database/`, validated against JSON Schema in
+`database/schemas/`. `database/index.json` is the manifest — **v1.6.0, 504 entities**.
+
+## Commands
+
+```bash
+python utils/lint_story.py                     # schemas, index counts, references resolve
+python utils/check_playability.py              # can a player actually get to it all
+python utils/export_canon_bundle.py --apply    # write the game's data/canon/ bundle
+python services/api/build_deploy.py --target vercel   # bundle the retrieval service
+```
+
+The first two gate every push. The exporter is a dry run unless you pass `--apply`.
+
+## The rules
+
+**Canon exports canon's own shape.** The game owns the adapters. An earlier design had the
+exporter emit the engine's flat `Creature` record, which made this schema hostage to a
+TypeScript interface in another repository; inverting that is why six entity types could be
+added later without a single Python edit on account of a game change.
+
+**Never hand-edit the game's `data/canon/`.** Change the entity here, re-export. A lock file and
+the game's CI enforce it.
+
+**Array order is load-bearing.** The game picks species by indexing into per-biome lists, so
+entities carry `source_index` and anything without one sorts last. Reordering silently changes
+what lives on somebody's tile.
+
+**Feature branches always.** Never commit to `main`.
+
+**Merging redeploys.** A push to `main` touching `database/` or `services/` rebuilds the search
+index, deploys it, and then asks the live `/health` whether its index covers canon. That last
+check exists because the service silently served a stale index for two whole field maps while
+reporting itself healthy.
+
+## Two things that are easy to get wrong
+
+**`check_playability.py` simulates.** It starts from nothing and repeatedly does whatever has
+become possible until nothing more opens. The obvious implementation — "is this requirement
+obtainable somewhere?" — passes a dependency cycle, and one shipped. It knowingly duplicates
+`holds` and `observed` from the game's `src/journey.ts`; change one, change both.
+
+**A requirement means two different things.** Climbing a rung needs what it stands on to be
+*understood*. Forming a reading of a question, or hearing a line, needs only that it has been
+*observed*. A hypothesis is built from what you have seen, not what you have finished — and
+under one uniform rule the wrong-but-early reading of a question becomes unreachable, which
+destroys the mechanic.
+
+## Where the reasoning lives
+
+| File | What it holds |
+|---|---|
+| `docs/decisions.md` | every call made on the project's behalf, and what is still open |
+| `DESIGN.md` | the binding rulings: the era, authored anchors, build-time reading |
+| `database/TODO.md` | which entities are missing |
+| `database/VALIDATION.md` | what the linters check |
+
+Read `docs/decisions.md` before changing anything structural. It records, among other things,
+why `full_moon` and `flood` are never generated, why the landmark loop stays, and why the
+Hugging Face model is stock GPT-2 that nothing uses.
+
+## Authoring a field map
+
+Measured across the four that exist: six points of interest, six to nine discoveries running
+three to seven rungs, one to three field questions, two or three people, **~1,700 words of
+prose**, about twenty JSON entities.
+
+The typing is not the constraint. Each map needs a **thesis** that is not a repeat: Lothal
+teaches looking, Narmada shows a record that begins at the wound, Dwarka is where local
+knowledge is simply right, the Dry Harbour is out of date rather than mysterious.
+
+A region can only hold a map if its biomes are `renderable` in `database/biomes.json`. The
+Shattered Sea is the only unbuilt region that qualifies today; the Tethys Sky Routes are blocked
+until sky biomes can be drawn, and the Ganges Lava Sea would render as `mountains` until
+`lava_field` has a tile.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,77 @@
-## Hugging Face Model Management
+# South of Tethys
 
-Model pushes to Hugging Face Hub are performed locally using `utils/test_hf_push.py`.
-This ensures large files and credentials are managed securely and are not exposed in CI/CD pipelines.
-The CI pipeline does not push models to Hugging Face.
-**🔗 Direct Links:**
-- Streamlit Portal: [southoftethys.streamlit.app](https://southoftethys.streamlit.app)
-- Hugging Face Model: [huggingface.co/lordlebu/4000BCSaraswaty](https://huggingface.co/lordlebu/4000BCSaraswaty)
+The **canon** for a shared fictional world, and the tools that keep it honest.
 
-# Vision: Expanding SouthOfTethys
+Everything canonical lives in [`database/`](database/) as one JSON file per entity, validated
+against JSON Schema and checked on every push — currently **v1.6.0, 504 entities**:
 
-SouthOfTethys aims to be a living, evolving worldbuilding engine that blends procedural generation, AI-powered narrative extraction, and collaborative storytelling. Our vision is to:
-- Enable seamless integration of human creativity and AI-driven structure
-- Support dynamic timelines, genealogies, and species evolution
-- Provide tools for both writers and developers to build, validate, and visualize complex worlds
-- Foster a community of worldbuilders who contribute lore, art, and code
-- Make all data and artifacts accessible, explorable, and reusable via open standards
+| | |
+|---|---|
+| **Species** | 256 fauna, 90 flora |
+| **World** | 7 regions, 2 settlements, 41 characters, 12 events, 3 factions, 3 artifacts |
+| **Field diary** | 4 field maps, 24 points of interest, 31 discoveries, 8 field questions, 10 people, 10 words |
 
-With the Vidur Portal and Hugging Face model, we empower users to extract structured data from stories, automate world consistency, and publish interactive artifacts for everyone to explore.
+## Two repositories, one world
+
+This one owns **what exists and what is true**. Its sibling,
+[4000BCESaraswathy](https://github.com/lordlebu/4000BCESaraswathy), is a browser game —
+*Varuna's Field Diary* — that owns **what a particular player did and how it looks**.
+
+The split holds because everything canon holds is a *noun* — places, species, discoveries,
+people, words — and everything the game holds is a *verb* or a *view*. Canon exports its own
+shape and the game owns adapters that translate it, so a change to the game's types never
+reaches back into a schema here.
+
+```
+database/  →  utils/export_canon_bundle.py  →  the game's data/canon/  →  src/content/*.ts
+```
+
+That bundle is generated and must never be hand-edited; a lock file and the game's CI enforce it.
+
+## Start here
+
+```bash
+pip install -r requirements.txt
+
+python utils/lint_story.py          # schemas, index counts, every cross-reference resolves
+python utils/check_playability.py   # can a player actually reach everything authored
+```
+
+Both gate every push. `check_playability.py` is a simulation rather than a set check — it starts
+from nothing and repeatedly does whatever has become possible, because asking instead whether
+each requirement is "obtainable somewhere" passes a dependency cycle, and one shipped.
+
+To publish changes to the game and the live service:
+
+```bash
+python utils/export_canon_bundle.py --apply    # write the game's bundle
+```
+
+Merging to `main` rebuilds and redeploys the retrieval service by itself, then checks the live
+index actually covers canon.
+
+## What is published
+
+- **[The book](https://lordlebu.github.io/SouthOfTethys/)** — timeline, maps and world data
+- **[Interactive world map](https://lordlebu.github.io/SouthOfTethys/interactive_map.html)**
+- **[Visual timeline](https://lordlebu.github.io/SouthOfTethys/timeline_mermaid.html)**
+- **[The game](https://lordlebu.github.io/4000BCESaraswathy/)** — the walk, built from this canon
+- **Retrieval API** — `/lore` for a place, `/search` for a question, `/ask` for a written passage
+
+Publishing is automatic on push. See [docs/PUBLISHING.md](docs/PUBLISHING.md) for the manual route.
+
+## Where the reasoning is written down
+
+| File | What it holds |
+|---|---|
+| [`CLAUDE.md`](CLAUDE.md) | orientation for agents working here |
+| [`docs/decisions.md`](docs/decisions.md) | every call made on the project's behalf, and what is still open |
+| [`DESIGN.md`](DESIGN.md) | the binding rulings: the era, authored anchors, build-time reading |
+| [`database/TODO.md`](database/TODO.md) | which entities are missing |
+
+Read `docs/decisions.md` before changing anything structural.
+
+---
 
 ## Developer checklist: Chroma index
 
@@ -82,26 +137,6 @@ To rebuild the index, re-run the indexer service only:
 ```powershell
 docker compose -f docker-compose.chroma.yml run --rm indexer
 ```
-# South of Tethys - Procedural Storytelling Engine
-
-A procedurally evolving storytelling engine inspired by world simulation games like **Dwarf Fortress**. This project manages story events, character genealogy, and evolving flora/fauna in a version-controlled Git repository. Story snippets are now processed using our own Hugging Face AI model for structured extraction.
-
-## 📖 Published Book & Artifacts
-
-The complete "book" of South of Tethys is automatically published with each update:
-
-- **📚 [View Published Book](https://lordlebu.github.io/SouthOfTethys/)** - Complete timeline, maps, and world data
-- **🗺️ [Interactive World Map](https://lordlebu.github.io/SouthOfTethys/interactive_map.html)** - Explore the world geography
-- **📊 [Visual Timeline](https://lordlebu.github.io/SouthOfTethys/timeline_mermaid.html)** - Event progression flowchart
-
-### 🚀 Publishing Your Changes
-
-1. **Make changes** to timeline, characters, or world data
-2. **Test locally**: `python utils/lint_story.py`
-3. **Commit and push** to trigger automatic publication
-4. **Manual publication**: Use [GitHub Actions](../../actions) → "CI" → "Run workflow"
-
-See **[📋 Publishing Workflow Guide](docs/PUBLISHING.md)** for complete instructions.
 
 ---
 
@@ -160,13 +195,41 @@ For most Python projects, start with:
 
 Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter checks.
 
-# Chronology of Jambudweepa  
+---
+
+## Story snippets
+
+Snippets are processed through the [Vidur Portal](vidur_portal/README.md), a separate web app,
+which replaced an earlier Ollama workflow.
+
+**A correction worth making plainly:** this README used to describe "our own Hugging Face AI
+model". The weights at [lordlebu/4000BCSaraswaty](https://huggingface.co/lordlebu/4000BCSaraswaty)
+are **stock GPT-2, unmodified, and nothing in the project uses them** — a 124M base model with no
+instruction tuning cannot write to a brief, which is why the service moved to retrieval plus an
+instruction-tuned model chosen at runtime by `CANON_LLM`. See [`model/README.md`](model/README.md).
+
+Model pushes are performed locally with `utils/test_hf_push.py`; CI does not push models.
+
+---
+
+## Where this is going
+
+A living worldbuilding engine rather than a finished world — one where structure and prose
+reinforce each other instead of drifting apart:
+
+- Canon that a machine can validate and a person can read, in the same files
+- Dynamic timelines, genealogies and species evolution, all cross-referenced
+- Tools that let writers and developers build, validate and visualise the same world
+- Everything explorable and reusable through open formats and a public retrieval API
+- A game that is *made of* the canon rather than a copy of it
+
+## Chronology of Jambudweepa  
 *From Primordial Seas to City-States*  
 
 ---
 
-## ⏳ **Prehistoric Foundations**  
-### (c. 500–250 Million Years Ago)  
+### ⏳ **Prehistoric Foundations**  
+#### (c. 500–250 Million Years Ago)  
 - **Invertebrate Dominion**:  
   Ammonoids rule shallow seas. The **Ammonite Man** emerges as first spiritual entity - a cephalopod sage whispering through coral reefs.  
 - **Avian-Synapsid Epoch**:  
@@ -174,8 +237,8 @@ Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter 
 
 ---
 
-## 🐒 **Age of Vanaras**  
-### (c. 50–5 Million Years Ago)  
+### 🐒 **Age of Vanaras**  
+#### (c. 50–5 Million Years Ago)  
 1. **Vanara Zenith**:  
    - Proto-primates develop tool use and fire mastery in **Gondwana forests**  
    - Build tree-cities in the **Nilgiri Canopy** (southern Jambudweepa)  
@@ -186,7 +249,7 @@ Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter 
 
 ---
 
-## 🚶 **Human Migrations**  
+### 🚶 **Human Migrations**  
 *(Wave Settlement Pattern: Northwest → East/South)*  
 
 | **Era**         | **Group**       | **Origin**          | **Settlement**          | **Key Traits**                  |  
@@ -198,8 +261,8 @@ Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter 
 
 ---
 
-## 🌀 **Spiritual Beings & Gates**  
-### (Timeless Entities)  
+### 🌀 **Spiritual Beings & Gates**  
+#### (Timeless Entities)  
 | **Being**         | **Manifestation**                     | **Domain**               |  
 |-------------------|---------------------------------------|--------------------------|  
 | **Ammonite Man**  | Spiraling nautilus-shell form         | Tethys Sea depths        |  
@@ -218,8 +281,8 @@ Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter 
 
 ---
 
-## 🏺 **Civilization Dawn**  
-### (c. 3000–500 BCE)  
+### 🏺 **Civilization Dawn**  
+#### (c. 3000–500 BCE)  
 1. **Harappan Emergence** (NW Origin):  
    - Cities rise along Saraswati River (Lothal, Dholavira)  
    - Trade with **Naga serpent-kingdoms** in Deccan  
@@ -232,7 +295,7 @@ Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter 
 
 ---
 
-## 👁️‍🗨️ **Current Era** (c. 500 BCE–Present)  
+### 👁️‍🗨️ **Current Era** (c. 500 BCE–Present)  
 | **Realm**         | **Inhabitants**                       | **Status**               |  
 |-------------------|---------------------------------------|--------------------------|  
 | **City-States**   | Humans (Vedda/Naga dominant)          | Flourishing              |  
@@ -259,11 +322,3 @@ Add `mypy`, `bandit`, and others as your codebase grows or if you need stricter 
 **🕰️ Timeline Key**  
 - **Bold** = Evolutionary turning points  
 - *Italics* = Spiritual manifestations
-
-## Story Snippet Processing
-
-Story snippets are now processed using our custom Hugging Face AI model via the [Vidur Portal](vidur_portal/README.md), an independent web application. This replaces the previous Ollama-based workflow and provides a user-friendly interface for extracting structured data from narrative text.
-
-To process a snippet:
-- Use the [Vidur Portal](vidur_portal/README.md) web app, which leverages our Hugging Face model for extraction.
-- The extracted data can be integrated into the SouthOfTethys world using the standard Python scripts.

--- a/database/README.md
+++ b/database/README.md
@@ -29,7 +29,7 @@ database/
 ## Species placement, and what empty `biomes` means
 
 Fauna and flora carry game-facing fields — `biomes`, `placement`, `rarity`, `mood`,
-`journal_prompt` — that `utils/export_game_data.py` projects into the game. `placement`
+`journal_prompt` — that `utils/export_canon_bundle.py` projects into the game. `placement`
 decides whether a species is ever met:
 
 | placement | meaning |
@@ -66,7 +66,7 @@ sapient lineages — Cognitavi, Nagaraptor, Vajraptor, Silvanus, Sylvians, Kuktu
 the Harappans regard them as animals, so a sentient species in the encounter table is
 correct and should not be "fixed".
 
-## Status (v1.1.0)
+## Status (v1.6.0 — 504 entities)
 
 | Category    | Count |
 |-------------|-------|
@@ -85,5 +85,8 @@ against the files. Note that check runs one way only, index → files, so an orp
 file is invisible to it.
 
 Do not recreate parallel entity stores outside this tree. The game's
-`data/creatures.json` and `data/flora.json` are a generated projection of this database,
-not a second store — see `utils/export_game_data.py`.
+The game's `data/canon/` bundle — `species.json`, `places.json`, `knowledge.json` and a lock
+file — is a generated projection of this database, not a second store. See
+`utils/export_canon_bundle.py`. It exports *canon's* shape; the game owns adapters under
+`src/content/` that turn it into engine structures, so a change to the engine's types never
+reaches back into a schema here.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -146,12 +146,12 @@ If you need to publish immediately without waiting for the normal workflow:
 │   ├── ci.yml                 # Main publishing workflow
 │   └── story-validation.yml   # Validation workflow
 ├── docs/                      # Published documentation (auto-generated)
-├── timeline/                  # Timeline data and generated summaries
-├── cartography/              # Maps and geographic data
-├── characters/               # Character profiles and genealogy
-├── flora_fauna/             # Species and evolution data
-├── utils/                   # Publishing and generation scripts
-└── requirements.txt         # Python dependencies
+├── database/                  # ALL canon: one JSON file per entity, plus schemas
+├── timeline/                  # Generated timeline artifacts
+├── cartography/               # Maps and geographic data
+├── services/                  # Retrieval API and the Chroma indexer
+├── utils/                     # Validation, export and generation scripts
+└── requirements.txt           # Python dependencies
 ```
 
 ## Script Reference
@@ -160,4 +160,9 @@ If you need to publish immediately without waiting for the normal workflow:
 - **`utils/generate_timeline_mermaid.py`** - Creates timeline visualizations
 - **`utils/generate_timeline.py`** - Processes and sorts timeline data
 - **`utils/generate_map.py`** - Creates interactive maps
-- **`utils/snippet_processor.py`** - Processes story snippets using LLM
+- **`utils/check_playability.py`** - Simulates a playthrough; fails on content nobody can reach
+- **`utils/export_canon_bundle.py`** - Writes the game's `data/canon/` bundle and its lock
+
+`characters/` and `flora_fauna/` used to appear in this tree. They were placeholder directories,
+removed when everything moved into `database/`, and `utils/snippet_processor.py` went with the
+Ollama workflow it belonged to.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,8 @@ ruff check ./utils/*.py --fix
 - Generate timeline (JSON): `python utils/generate_timeline.py`
 - Simulate species evolution: `python utils/evolve_species.py`
 - Generate maps: `python utils/generate_map.py`
-- Process story snippets (requires Ollama running locally): `python utils/snippet_processor.py`
+- Process story snippets: see `vidur_portal/README.md`. The Ollama step this used to
+  describe was replaced by the portal, and `utils/snippet_processor.py` no longer exists.
 
 ## 🎭 About This World
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -117,7 +117,7 @@ it stays local too.
 strips it from any error before it reaches a response. Never put it in a `VITE_` variable:
 Vite inlines those into the game's public bundle.
 
-The style examples in the prompt are read from canon (`utils/export_game_data.py` writes the
+The style examples in the prompt are read from canon (`utils/export_canon_bundle.py` writes the
 same sentences into the game), so the voice shown to the model cannot drift from the voice
 the player reads.
 


### PR DESCRIPTION
.github/copilot-instructions.md described a repository that has not existed for some time -- timeline/timeline.json, characters/, flora_fauna/, locations/, an Ollama extraction step -- all replaced by database/ long ago. Anything reading it was being actively misdirected, which is worse than having no file. Rewritten from what is actually here.

Adds CLAUDE.md, which this repo had none of: the noun/verb split that settles most questions, the commands that gate a push, why check_playability simulates rather than checks membership, why a requirement means "understood" when climbing and "observed" when reasoning, and what a field map costs.

README.md is restructured rather than patched. It had grown by accretion into three H1-level titles with the project's own name at line 85, beneath a section on Hugging Face model management -- so a reader met the deployment details of an unused model before learning what the project is. It now opens with what this is, the two-repo split, what canon currently holds, and how to run the checks; the chronology, the Chroma checklist and the pre-commit setup are kept verbatim further down, and the Vision section is kept in trimmed form.

Two claims in it were false and are corrected: "our own Hugging Face AI model" and "our custom Hugging Face AI model" both describe weights that are stock GPT-2 and that nothing in the project uses, which model/README.md already says plainly.

The rest is corrected by evidence rather than by sweep. database/README.md named utils/export_game_data.py and data/creatures.json, neither of which exists, and reported v1.1.0 against a v1.6.0 index. services/api/README.md named the same dead exporter. docs/README.md and docs/PUBLISHING.md documented utils/snippet_processor.py, which is gone, and PUBLISHING drew two removed directories in its tree.

CONTEXT.md and DESIGN.md were checked and left alone -- they already say those directories were removed, which is correct.