### PR TITLE
Record that the branch rule is enforced, not trusted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,20 @@ the game's CI enforce it.
 entities carry `source_index` and anything without one sorts last. Reordering silently changes
 what lives on somebody's tile.
 
-**Feature branches always.** Never commit to `main`.
+**Feature branches always.** Never commit to `main` — and this is now enforced rather than
+trusted. A ruleset on the default branch blocks direct pushes, force pushes and deletions, and
+requires a pull request whose `validate` check has passed. There is **no bypass, for anyone**,
+including the repository owner.
+
+That last part has a consequence worth knowing before it bites: if a required check ever hangs
+or its workflow breaks, `main` cannot be merged to or repaired until the rule is relaxed. The
+recovery is Settings → Rules → Rulesets → *Protect main* → Enforcement: **Disabled**, merge the
+fix, then set it back to Active.
+
+Only `validate`, from `story-validation.yml`, is required. The jobs in `ci.yml` are deliberately
+*not*, because that workflow is path-filtered to `utils/**`, `database/**`, `cartography/**` and
+a few others — requiring one would leave a documentation-only pull request pending forever
+rather than failing, which is the worse outcome of the two.
 
 **Merging redeploys.** A push to `main` touching `database/` or `services/` rebuilds the search
 index, deploys it, and then asks the live `/health` whether its index covers canon. That last


### PR DESCRIPTION
CLAUDE.md said "never commit to main" as a convention, which is the kind of rule only a person can honour. A ruleset now blocks direct pushes, force pushes and deletions on the default branch and requires a passing `validate` check.

It says which check is required and, more usefully, which are not: everything in ci.yml is path-filtered to utils/, database/, cartography/ and a few others, so requiring one would leave a documentation-only pull request pending forever rather than failing it. Pending is the worse of the two -- it looks like the check is still running.

There is no bypass, for anyone, which is a deliberate choice with a consequence worth writing down before it is discovered mid-incident: a hung check means main cannot be merged to or repaired until the rule is relaxed. The recovery path is recorded rather than left to be worked out under pressure.