### PR TITLE
The Shrīmā, and which of the two accounts canon keeps

### DIFF
--- a/database/fauna/fauna_shrima.json
+++ b/database/fauna/fauna_shrima.json
@@ -1,0 +1,39 @@
+{
+  "id": "fauna_shrima",
+  "type": "fauna",
+  "name": "Shrīmā",
+  "aliases": [
+    "Srima",
+    "Lagoon Queens"
+  ],
+  "scientific": "Eurypterus mimeticus",
+  "taxonomy": {
+    "notes": "Giant eurypterid, Merostomata; a deep-time survivor of the Invertebrate Dominion"
+  },
+  "diet": "Carnivore",
+  "habitats": [
+    "region_shattered_sea"
+  ],
+  "behaviour": [
+    "ambush",
+    "camouflage",
+    "aquatic",
+    "ocular_mimicry"
+  ],
+  "notes": "The islanders read them as fallen sky-mystics who chose the shallows; the Narmada reading is that a eurypterid lineage has evolved toward the human silhouette as a lure. Both accounts describe the same animal, and the folklore is the older of the two. Dr. Digha Jani's lecture notes are the source for the second, and she is careful to say the mimicry is of *shape*, not of mind.",
+  "canon": "primary",
+  "sources": [
+    "docs/bestiary.md",
+    "Palm-Leaf Manuscript of iKnaya Subayai"
+  ],
+  "region": "shattered-sea-mappa-mundi",
+  "biomes": [
+    "coast",
+    "sea"
+  ],
+  "placement": "encounter",
+  "rarity": "mythic",
+  "journal_prompt": "Something stands in the shallow lagoon at dusk, draped in seaweed-silk and cowrie shells, swaying as though dancing. The proportions are almost right. The antennae are not.",
+  "mood": "uncanny",
+  "source_index": 236
+}

--- a/database/index.json
+++ b/database/index.json
@@ -4,7 +4,7 @@
   "counts": {
     "characters": 41,
     "events": 12,
-    "fauna": 256,
+    "fauna": 257,
     "flora": 90,
     "settlements": 2,
     "regions": 7,
@@ -272,6 +272,7 @@
       "fauna_shattered_sea_oyster",
       "fauna_shell_turtle",
       "fauna_shilajit_guardian_lizard",
+      "fauna_shrima",
       "fauna_silver_banded_sea_snake",
       "fauna_sky_dragon_fly",
       "fauna_sky_faring_crab",


### PR DESCRIPTION
A giant eurypterid of the Tamralinga lagoons that has evolved toward the human silhouette, and is not a fallen sky-mystic whatever the islanders say.

The two-truths shape is the point and both halves are kept. The folklore is the older account and the one a traveller hears first; the Narmada reading is that the mimicry is of shape rather than of mind, which is worse. `notes` carries both and says which is which, because that distinction is the entity -- flatten it to one explanation and there is nothing left worth writing down.

Placed rather than lore. `coast` and `sea` are both renderable and both appear on the Lothal and Dwarka maps, so this is met at a shoreline rather than filed for a region that has no field map yet. Mythic rarity keeps it to roughly one encounter pool draw in eight.

`source_index` is 236, past every existing entry. The game picks species by indexing per-biome lists, so an index inserted mid-sequence would silently change what lives on somebody's tile in an existing save.

Dropped from the proposed record: `game_stats` with elemental affinities and a hazard rating, which imply a combat system this game does not have and should not grow by accident -- creatures here are observed, not fought. Also `spawn_hours` and a coordinate restriction, which the engine has no way to honour: placement is a tile hash over a per-biome list, with no time gate and no coordinate filter. Storing fields nothing reads is how a schema starts lying.