### PR TITLE
Somebody came back for it

### DIFF
--- a/database/discoveries/discovery_chamber_below.json
+++ b/database/discoveries/discovery_chamber_below.json
@@ -1,0 +1,55 @@
+{
+  "type": "discovery",
+  "epochs": [
+    "epoch_post_cataclysm"
+  ],
+  "canon": "primary",
+  "sources": [
+    "Varuna's Field Diary design"
+  ],
+  "id": "discovery_chamber_below",
+  "name": "Somebody Came Back For It",
+  "discipline": "archaeology",
+  "subject": "faction_mask_family",
+  "found_at": [
+    "poi_kavik_tower"
+  ],
+  "related_discoveries": [
+    "discovery_mask_niche",
+    "discovery_tower_collapse"
+  ],
+  "levels": [
+    {
+      "entry": "The undercroft is not one room. There is a second, behind the west wall, and the wall is a wall on one side only."
+    },
+    {
+      "entry": "It was closed from the outside and it was closed in a hurry -- the facing stones are the right stones, put back in the wrong order.",
+      "requires": [
+        "discovery_mask_niche"
+      ]
+    },
+    {
+      "entry": "Inside there is a shelf at shoulder height, cut for something specific, and empty. It is the same height as the niche in the stair, and it is the same shape."
+    },
+    {
+      "entry": "So the thing that stood in the stair was brought down here and put behind a wall. Not hidden from thieves -- a thief does not rebuild the wall behind him -- hidden from something that was already inside the building."
+    },
+    {
+      "entry": "There is soot on the shelf and none anywhere else. Something burned in a room with no chimney, which is a thing you do once and quickly."
+    },
+    {
+      "entry": "The mortar is post-collapse. Whatever happened here happened after the tower sat down, which is to say the city was already broken and somebody came back into it for this.",
+      "requires": [
+        "discovery_tower_collapse"
+      ]
+    },
+    {
+      "entry": "The shelf is empty too. Whoever sealed the room came back and took it, and I cannot say who, or when, or whether it was the same hands. Uvai. A thing remembered, which is what the Kia call the part of a story that outlasts the people in it -- and this is the shape of one with the middle gone.",
+      "requires": [
+        "word_kia_uvai",
+        "discovery_ghost_mangrove_channel"
+      ]
+    }
+  ],
+  "notes": "The mask thread, extending `discovery_mask_niche` without resolving it. Canon knows the answer -- `event_tendua_crisis` and `event_mask_retrieval` name Nila, Asha, iKnaya and Varna -- and none of those names appears here, on purpose: who took it should stay unanswered, and `lint_story.py` now enforces that against the cast list rather than trusting it. The niche's own note says who took the mask 'should stay unanswered for a long time; the diary needs entries the player cannot finish', and this is written to that constraint rather than around it.\n\nWhat Varuna can reach is the *event*: a chamber, opened and closed in a hurry, something burned, a shelf cut for the thing the stair niche also held, and mortar that dates it after the collapse. What he cannot reach is a person. The last rung says so out loud, which is the honest end of an archaeological reading and a better entry than a solved case.\n\nEvery prerequisite is on Lothal. `word_kia_uvai` comes from Thrali after `discovery_ghost_mangrove_channel`, which this also requires and which opens the flooded undercroft in the first place -- so the word is always gettable before this chain needs it. That ordering is deliberate: the two-bar trap is requiring a word an NPC only gives once the requiring chain is already finished."
+}

--- a/database/index.json
+++ b/database/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "SouthOfTethys canonical entity index",
   "counts": {
     "characters": 41,
@@ -13,7 +13,7 @@
     "mythology": 3,
     "field_maps": 3,
     "points_of_interest": 20,
-    "discoveries": 30,
+    "discoveries": 31,
     "field_questions": 7,
     "npcs": 8,
     "vocabulary": 8
@@ -485,6 +485,7 @@
     "discoveries": [
       "discovery_archive_baseline",
       "discovery_bitter_millet",
+      "discovery_chamber_below",
       "discovery_cloud_stair",
       "discovery_dockyard_reef",
       "discovery_double_classified",

--- a/database/points_of_interest/poi_kavik_tower.json
+++ b/database/points_of_interest/poi_kavik_tower.json
@@ -17,7 +17,8 @@
   "discoveries": [
     "discovery_tower_collapse",
     "discovery_mask_niche",
-    "discovery_kiln_draught"
+    "discovery_kiln_draught",
+    "discovery_chamber_below"
   ],
   "sub_locations": [
     {

--- a/utils/lint_story.py
+++ b/utils/lint_story.py
@@ -176,6 +176,37 @@ def main() -> int:
             if ref not in known:
                 errors.append(f"{path.name}: reference '{ref}' does not exist")
 
+    # --- names the player is not meant to reach -----------------------------------
+    #
+    # A discovery whose own notes say a thing "should stay unanswered" is a promise, and prose is
+    # the one place nothing else checks. Canon knows who took the mask -- `event_tendua_crisis`
+    # names Nila -- and a rung that says so would quietly close a thread the design wants left
+    # open. This is cheap to break by accident and impossible to notice by reading a schema.
+    #
+    # Only rungs the player reads are checked. `notes` is for the canon reader and is where the
+    # answer belongs.
+    sealed = {
+        eid: payload
+        for eid, (_, payload) in entities.items()
+        if payload.get("type") == "discovery" and "stay unanswered" in (payload.get("notes") or "")
+    }
+    if sealed:
+        cast = set()
+        for _eid, (_p, payload) in entities.items():
+            if payload.get("type") == "character":
+                cast.add(payload.get("name", ""))
+                cast.update(payload.get("aliases") or [])
+        cast = {n for n in cast if len(n) > 3}
+
+        for eid, payload in sealed.items():
+            prose = " ".join(l.get("entry", "") for l in payload.get("levels", []))
+            for name in sorted(cast):
+                if name in prose:
+                    errors.append(
+                        f"{eid}: rung prose names '{name}', but its notes say the answer "
+                        f"should stay unanswered"
+                    )
+
     print(f"  schema     : {schema_note}")
     print(f"  entities   : {len(entities)}")
     print(f"  epochs     : {len(declared)} declared")


### PR DESCRIPTION
The mask thread on Lothal, extending the empty niche without resolving it. Seven rungs in the flooded undercroft: a second room behind a wall that is a wall on one side only, closed in a hurry with the right stones in the wrong order, a shelf cut for the same shape the stair niche held, soot in a room with no chimney, and mortar that dates all of it after the tower sat down.

Varuna reaches the event. He does not reach a person, and the last rung says so: "I cannot say who, or when, or whether it was the same hands."

Canon knows the answer. `event_tendua_crisis` names Nila and `event_mask_retrieval` names Asha, iKnaya and Varna, and none of those names appears in a rung. The niche's own note says who took the mask "should stay unanswered for a long time -- the diary needs entries the player cannot finish", and this is written to that constraint rather than around it. An archaeological reading that ends honestly short is a better entry than a solved case.

`lint_story.py` now enforces that rather than trusting it. Any discovery whose notes say "stay unanswered" has its rung prose checked against canon's whole cast list, because prose is the one place nothing else looks and a name is cheap to add by accident. Verified by putting "It was Nila who took it" into the last rung and watching the lint name both the character and the file.

Every prerequisite is on Lothal, and the ordering avoids the two-bar trap on purpose: `word_kia_uvai` comes from Thrali after the mangrove channel, which this chain also requires and which is what opens the undercroft in the first place -- so the word is always gettable before this needs it. Checked the other way too, by making a rung require its own chain and watching the playability simulation refuse it.

Lothal goes from 13 finishable discoveries to 14. Index 1.9.0.