### PR TITLE
Let the people say what the work was for

### DIFF
--- a/database/npcs/npc_bekh.json
+++ b/database/npcs/npc_bekh.json
@@ -39,6 +39,24 @@
       "requires": [
         "discovery_mask_niche"
       ]
+    },
+    {
+      "text": "The north chamber is clear. The water was still falling under all that silt -- it never stopped, it only stopped being able to reach anything. We threshed in a morning what takes us four days. My mother would have called that a miracle and been wrong twice.",
+      "requires": [
+        "discovery_granary_fall"
+      ]
+    },
+    {
+      "text": "We are not moving in the spring. I have counted it four times and it keeps coming out the same, which is not something I am used to. Nine times I have moved this camp. My daughter will be the first of us to know what a place looks like in its second year.",
+      "requires": [
+        "discovery_winter_line"
+      ]
+    },
+    {
+      "text": "Eight acres, sown from the granary wall. It will be a poor crop for three years and it will be a crop, which is three years better than a field we plant every spring out of habit. My mother planted it. Her mother planted it. Neither of them ever got anything back.",
+      "requires": [
+        "discovery_red_rice_survival"
+      ]
     }
   ],
   "epochs": [

--- a/database/npcs/npc_marn.json
+++ b/database/npcs/npc_marn.json
@@ -35,6 +35,12 @@
       "requires": [
         "discovery_bitter_millet"
       ]
+    },
+    {
+      "text": "So the spring moved and the archive did not. I have been grazing off the old mark my whole life and telling myself the water was unreliable. The water is fine. It is the mark that is wrong, and a mark is a thing a person put there.",
+      "requires": [
+        "discovery_moving_spring"
+      ]
     }
   ],
   "notes": "Holds two of the map's answers inside ordinary vocabulary and has never had a reason to examine either. The counterpart to Thrali, and pointedly not a wise elder -- he is a working herder with a job on.",

--- a/database/npcs/npc_okhi.json
+++ b/database/npcs/npc_okhi.json
@@ -34,6 +34,12 @@
       "requires": [
         "discovery_terrace_script"
       ]
+    },
+    {
+      "text": "One bird, two entries, thirty years apart, and I have dusted both shelves. Nobody rereads. I am going to start at the oldest and work forward, and I expect it will take the rest of my life, and I would rather know.",
+      "requires": [
+        "discovery_double_classified"
+      ]
     }
   ],
   "notes": "The one who will not come. Deliberately not a tragedy and not a rebuke -- she is right that somebody has to stay, and the ending should let her be right rather than treating her as a failed recruitment.",

--- a/database/npcs/npc_sura.json
+++ b/database/npcs/npc_sura.json
@@ -36,6 +36,12 @@
       "requires": [
         "discovery_fever_root_spread"
       ]
+    },
+    {
+      "text": "Layers, yes. My mother knew where the thin ones were and I know, and neither of us knew why. It is not a thing that happened to Dwarka. It is what Dwarka is, and we already had a word for it and a place to put the bones.",
+      "requires": [
+        "discovery_midden_layers"
+      ]
     }
   ],
   "notes": "Holds four hundred years of stratigraphy as a family trade and has never been asked. Would settle -- the midden is a living, not a home.",

--- a/database/npcs/npc_thrali.json
+++ b/database/npcs/npc_thrali.json
@@ -38,6 +38,18 @@
       "gives": [
         "word_kia_uvai"
       ]
+    },
+    {
+      "text": "I can see the bottom. Do you understand what I am telling you -- I have set nets by feel for nineteen years and this morning I looked through a piece of the eastern field and saw the channel bed. The field nobody could plant. It was giving us this the whole time.",
+      "requires": [
+        "discovery_salt_glass"
+      ]
+    },
+    {
+      "text": "Bekh has it written down. Four months a year I could not fish and now I can, and the reason is a kiln and a mill and a piece of glass, none of which is mine. I do not entirely follow it. I am not going to argue with a full net.",
+      "requires": [
+        "discovery_winter_line"
+      ]
     }
   ],
   "epochs": [

--- a/database/npcs/npc_uma.json
+++ b/database/npcs/npc_uma.json
@@ -19,6 +19,18 @@
       "requires": [
         "discovery_saltreed_thatch"
       ]
+    },
+    {
+      "text": "You were right about the wind. We turned the spring kiln to face the plateau and it fired in a day, on half the reed. Half. I have been cutting twice what I needed since I was fourteen and nobody ever stood in the doorway and looked at which way the smoke went.",
+      "requires": [
+        "discovery_kiln_draught"
+      ]
+    },
+    {
+      "text": "Bekh says we are staying. So I am going to put a proper roof on the kiln shed, the kind you build when you expect to be under it. It will take three weeks and there is no reason to hurry, which is the strangest part.",
+      "requires": [
+        "discovery_winter_line"
+      ]
     }
   ],
   "epochs": [

--- a/utils/lint_story.py
+++ b/utils/lint_story.py
@@ -176,6 +176,34 @@ def main() -> int:
             if ref not in known:
                 errors.append(f"{path.name}: reference '{ref}' does not exist")
 
+    # --- help nobody mentions ------------------------------------------------------
+    #
+    # `helps` is the whole of the "help people" system: a discovery names somebody whose life it
+    # mends, and reaching the actionable rung is what mends it. But the field is only data. The
+    # first solarpunk chain shipped with four discoveries naming three people and **not one line
+    # from any of them acknowledging it** -- the camp's spring was turned around and nobody
+    # mentioned it, which is why none of it landed when the game was played.
+    #
+    # So a discovery that says it helps somebody must be somebody's business to talk about.
+    helped = {}
+    for eid, (_p, payload) in entities.items():
+        if payload.get("type") != "discovery":
+            continue
+        for who in payload.get("helps") or []:
+            helped.setdefault(who, []).append(eid)
+
+    for who, discoveries in sorted(helped.items()):
+        person = entities.get(who)
+        if person is None:
+            continue
+        prose = json.dumps(person[1].get("lines") or [])
+        for did in discoveries:
+            if did not in prose:
+                errors.append(
+                    f"{who}: {did} says it helps them, but they have no line requiring it -- "
+                    f"help nobody mentions is a field in a file"
+                )
+
     # --- names the player is not meant to reach -----------------------------------
     #
     # A discovery whose own notes say a thing "should stay unanswered" is a promise, and prose is


### PR DESCRIPTION
The last of the second round, and the fix for "nothing of solarpunk stood out". Four discoveries named three people in `helps` and not one of them had a line acknowledging it: the camp's spring was turned around, the mill ran again, the field gave up glass, and nobody mentioned any of it. The help existed only as a field in a JSON file.

Uma has fired a spring kiln on half the reed. Bekh threshed in a morning what takes four days. Thrali can see the channel bed for the first time in nineteen years. And the capstone gets two: Bekh counting it four times because she is not used to a number coming out the same, and Uma deciding to put a proper roof on the kiln shed -- the kind you build when you expect to be under it.

`lint_story.py` now refuses a discovery whose `helps` nobody mentions, and it found four more the moment it ran: `moving_spring`, `double_classified`, `midden_layers` on the other two maps, and `winter_line` for Thrali. Those have lines now too, and so does `red_rice_survival`, which sows the very field Bekh's own question is about and had been silent since the beginning.

That is the check earning its place on its first run rather than guarding a thing already fixed. Verified by deleting Uma's line and watching the lint name her and the discovery.