### PR TITLE
Every plant now says what shape it is

### DIFF
--- a/database/VALIDATION.md
+++ b/database/VALIDATION.md
@@ -21,6 +21,7 @@ It is now a list of what is enforced, which is a thing that can be checked again
 | **epochs** | Any field whose *name* mentions an epoch resolves to `timeline/epochs.json` — not just `epoch` and `epochs`, because `epoch_founded` once sat unvalidated one field over. |
 | **references** | Any string matching a known id prefix resolves to an entity that exists, wherever it appears in the tree. |
 | **clade** | Every fauna states one, from the sixteen in `database/clades.json`. Required, so a new species cannot ship without saying what it is. |
+| **growth form** | Every flora states one, from the fourteen in `database/growth_forms.json`. Required, and the value is checked against that file as well as the schema — the two can drift apart otherwise. |
 | **subclade** | Where given, it must be a sub-group of *that* clade. A cross-field dependency, so it lives in the linter: JSON Schema checks each field against a flat enum and would let a bird be a dromaeosaurid. |
 | **unique binomial** | No two fauna, and no two flora, share a `scientific`. |
 | **unique name** | No two entities *in the same folder* share a `name`. Across folders is allowed and correct: `Dwarka` is both a settlement and the field map of it. |
@@ -37,10 +38,10 @@ it was describing. Exactly the failure mode this document exists to avoid.
 
 | Gap | Status |
 |---|---|
-| **Flora clades** | All 256 fauna state their clade; the 90 flora do not. Their growth form is still derived from names game-side, exactly the way body plans were before this. |
 | **`taxonomy` shape** | Still `{"type": "object"}` with no required keys, on 9 of 256 fauna. Left free on purpose: Phase 03 answered the part that mattered with a real `clade` field, and what remains here is genuinely editorial notes. |
 | **Geography beyond field maps** | Field maps carry `coordinates`; the ~15 other places on the lore map are not entities at all. Deliberate, and sequenced — see `docs/canon-integrity-plan.md`. |
 | **Large media placement** | Nothing checks that a big binary sits in the git-ignored `dump/` rather than tracked. A 6.4 MB lore map reached a commit through `git add -A`. The rule is in `CLAUDE.md`; a size check in lint would enforce it and has not earned its place — one accident is not a pattern, and a linter that failed on a file somebody deliberately tracked would be worse than the accident. |
+| **Corals filed as flora** | Canon's two *Tethysolithus* reef-builders are cnidarians — animals — and sit in `database/flora/`. They carry `growth_form: coral` so the database stops implying they are plants, but moving them to `fauna` with a `clade` is a canon decision nobody has made. |
 | **Spouse field** | Sometimes an array, sometimes a string. The schema stays permissive; long-standing and non-blocking. |
 
 ## The rule this file exists to enforce on itself

--- a/database/flora/flora_aero_mangrove_vayu_vriksha.json
+++ b/database/flora/flora_aero_mangrove_vayu_vriksha.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Aero-Mangrove / Vayu-Vriksha",
   "scientific": "Rhizophora caelia",
+  "growth_form": "tree",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_antarctic_kelp_grass.json
+++ b/database/flora/flora_antarctic_kelp_grass.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Antarctic Kelp-Grass",
   "scientific": "Zostera antarctica",
+  "growth_form": "grass",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_asura_tainted_flesh_vine.json
+++ b/database/flora/flora_asura_tainted_flesh_vine.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Asura-Tainted Flesh-Vine",
   "scientific": "Vitis carnosa",
+  "growth_form": "vine",
   "region": "asura-conjurations",
   "biomes": [
     "forest"

--- a/database/flora/flora_asura_thorn.json
+++ b/database/flora/flora_asura_thorn.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Asura Thorn",
   "scientific": "Ziziphus asurica",
+  "growth_form": "shrub",
   "habitats": [
     "corrupted_zones",
     "region_aravali"

--- a/database/flora/flora_bamboo_grove.json
+++ b/database/flora/flora_bamboo_grove.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "River Bamboo",
   "scientific": "Bambusa saraswati",
+  "growth_form": "grass",
   "habitats": [
     "region_saraswati_delta",
     "region_narmada_plateau"

--- a/database/flora/flora_bitter_black_barley.json
+++ b/database/flora/flora_bitter_black_barley.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Bitter Black Barley",
   "scientific": "Hordeum niger",
+  "growth_form": "grass",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_bitter_marsh_root.json
+++ b/database/flora/flora_bitter_marsh_root.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Bitter Marsh-root",
   "scientific": "Sarasvatia amara",
+  "growth_form": "root",
   "region": "saraswati-godavari-deltas",
   "biomes": [
     "wetland"

--- a/database/flora/flora_black_ash_tea.json
+++ b/database/flora/flora_black_ash_tea.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Black Ash-Tea",
   "scientific": "Camellia vulcanica",
+  "growth_form": "shrub",
   "habitats": [
     "region_narmada_plateau"
   ],

--- a/database/flora/flora_blood_red_asura_lotus.json
+++ b/database/flora/flora_blood_red_asura_lotus.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Blood-red Asura Lotus",
   "scientific": "Nelumbo asurica",
+  "growth_form": "flower",
   "habitats": [
     "corrupted_zones"
   ],

--- a/database/flora/flora_blue_healing_turmeric.json
+++ b/database/flora/flora_blue_healing_turmeric.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Blue Healing Turmeric",
   "scientific": "Curcuma caerulea",
+  "growth_form": "root",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_blue_pulse_root.json
+++ b/database/flora/flora_blue_pulse_root.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Blue Pulse-Root",
   "scientific": "Nirnroot caerulea",
+  "growth_form": "root",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island",

--- a/database/flora/flora_blue_scholar_s_moss.json
+++ b/database/flora/flora_blue_scholar_s_moss.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Blue Scholar's Moss",
   "scientific": "Dictyonema caeruleum",
+  "growth_form": "lichen",
   "region": "narmada-vindhya",
   "biomes": [
     "hills",

--- a/database/flora/flora_bonewood_mangrove.json
+++ b/database/flora/flora_bonewood_mangrove.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Bonewood Mangrove",
   "scientific": "Rhizophora osteoxyla",
+  "growth_form": "tree",
   "habitats": [
     "coastal",
     "region_saraswati_delta"

--- a/database/flora/flora_cloud_weaver_vine.json
+++ b/database/flora/flora_cloud_weaver_vine.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Cloud-Weaver Vine",
   "scientific": "Vitis nubis",
+  "growth_form": "vine",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_crimson_blood_weed.json
+++ b/database/flora/flora_crimson_blood_weed.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Crimson Blood-Weed",
   "scientific": "Vitis asurica",
+  "growth_form": "vine",
   "region": "asura-conjurations",
   "biomes": [
     "forest"

--- a/database/flora/flora_crimson_leaved_ash_banyan.json
+++ b/database/flora/flora_crimson_leaved_ash_banyan.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Crimson-Leaved Ash-Banyan",
   "scientific": "Ficus ash-banyana",
+  "growth_form": "tree",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_crimson_spice_root.json
+++ b/database/flora/flora_crimson_spice_root.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Crimson Spice-Root",
   "scientific": "Curcuma rubra",
+  "growth_form": "root",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_cursed_ash_fern.json
+++ b/database/flora/flora_cursed_ash_fern.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Cursed Ash-Fern",
   "scientific": "Pteris asurica",
+  "growth_form": "fern",
   "region": "asura-conjurations",
   "biomes": [
     "forest",

--- a/database/flora/flora_date_palm.json
+++ b/database/flora/flora_date_palm.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Date Palm",
   "scientific": "Phoenix gedrosiana",
+  "growth_form": "palm",
   "habitats": [
     "region_gedrosian_desert"
   ],

--- a/database/flora/flora_deep_earth_obsidian_lotus.json
+++ b/database/flora/flora_deep_earth_obsidian_lotus.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Deep-Earth Obsidian Lotus",
   "scientific": "Nymphaea obsidiana",
+  "growth_form": "flower",
   "region": "ganges-lava-sea",
   "biomes": [
     "wetland"

--- a/database/flora/flora_desert_saltbush.json
+++ b/database/flora/flora_desert_saltbush.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Desert Saltbush",
   "scientific": "Atriplex gedrosia",
+  "growth_form": "shrub",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_emerald_harbor_lotus.json
+++ b/database/flora/flora_emerald_harbor_lotus.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Emerald Harbor Lotus",
   "scientific": "Nelumbo smaragdina",
+  "growth_form": "flower",
   "habitats": [
     "region_saraswati_delta",
     "settlement_lothal"

--- a/database/flora/flora_fever_root.json
+++ b/database/flora/flora_fever_root.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Fever-Root",
   "scientific": "Curcuma asurica",
+  "growth_form": "root",
   "region": "asura-conjurations",
   "biomes": [
     "underworld"

--- a/database/flora/flora_frankincense_scrub.json
+++ b/database/flora/flora_frankincense_scrub.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Frankincense Scrub",
   "scientific": "Boswellia gedrosiana",
+  "growth_form": "shrub",
   "habitats": [
     "region_gedrosian_desert",
     "region_aravali"

--- a/database/flora/flora_ghost_mangrove.json
+++ b/database/flora/flora_ghost_mangrove.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Ghost Mangrove",
   "scientific": "Avicennia phantasma",
+  "growth_form": "tree",
   "habitats": [
     "coastal",
     "region_saraswati_delta"

--- a/database/flora/flora_giant_bird_nest_fern.json
+++ b/database/flora/flora_giant_bird_nest_fern.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Giant Bird-Nest Fern",
   "scientific": "Asplenium maximus",
+  "growth_form": "fern",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "forest"

--- a/database/flora/flora_giant_mangrove_palm.json
+++ b/database/flora/flora_giant_mangrove_palm.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Giant Mangrove-Palm",
   "scientific": "Nypa gigas",
+  "growth_form": "palm",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "coast"

--- a/database/flora/flora_glacial_lichen.json
+++ b/database/flora/flora_glacial_lichen.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Glacial Lichen",
   "scientific": "Lichen glacialis",
+  "growth_form": "lichen",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_golden_amber_lotus.json
+++ b/database/flora/flora_golden_amber_lotus.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Golden Amber Lotus",
   "scientific": "Nymphaea succinea",
+  "growth_form": "flower",
   "region": "ganges-lava-sea",
   "biomes": [
     "wetland"

--- a/database/flora/flora_golden_ember_leaf.json
+++ b/database/flora/flora_golden_ember_leaf.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Golden Ember-Leaf",
   "scientific": "Camellia aurata",
+  "growth_form": "shrub",
   "region": "narmada-vindhya",
   "biomes": [
     "hills",

--- a/database/flora/flora_golden_sun_barley.json
+++ b/database/flora/flora_golden_sun_barley.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Golden Sun-Barley",
   "scientific": "Hordeum aureum",
+  "growth_form": "grass",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert",

--- a/database/flora/flora_hanging_monkey_pitcher.json
+++ b/database/flora/flora_hanging_monkey_pitcher.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Hanging Monkey-Pitcher",
   "scientific": "Nepenthes vanara",
+  "growth_form": "pitcher",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "forest"

--- a/database/flora/flora_healing_silver_root.json
+++ b/database/flora/flora_healing_silver_root.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Healing Silver-root",
   "scientific": "Sarasvatia argentum",
+  "growth_form": "root",
   "region": "saraswati-godavari-deltas",
   "biomes": [
     "wetland",

--- a/database/flora/flora_highland_bitter_mahua.json
+++ b/database/flora/flora_highland_bitter_mahua.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Highland Bitter Mahua",
   "scientific": "Madhuca montana",
+  "growth_form": "tree",
   "region": "narmada-vindhya",
   "biomes": [
     "mountains"

--- a/database/flora/flora_hourglass_cactus.json
+++ b/database/flora/flora_hourglass_cactus.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Hourglass Cactus",
   "scientific": "Cereus arenarius",
+  "growth_form": "cactus",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_indigo_wild.json
+++ b/database/flora/flora_indigo_wild.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Wild Indigo",
   "scientific": "Indigofera silvestris",
+  "growth_form": "shrub",
   "habitats": [
     "region_saraswati_delta",
     "region_aravali"

--- a/database/flora/flora_iron_root_mangrove.json
+++ b/database/flora/flora_iron_root_mangrove.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Iron-Root Mangrove",
   "scientific": "Rhizophora ferrea",
+  "growth_form": "tree",
   "region": "saraswati-godavari-deltas",
   "biomes": [
     "coast"

--- a/database/flora/flora_iron_teak.json
+++ b/database/flora/flora_iron_teak.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Iron-Teak",
   "scientific": "Tectona ferrea",
+  "growth_form": "tree",
   "habitats": [
     "region_narmada_plateau",
     "region_aravali"

--- a/database/flora/flora_ivory_coastal_bonewood.json
+++ b/database/flora/flora_ivory_coastal_bonewood.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Ivory Coastal Bonewood",
   "scientific": "Rhizophora eburnea",
+  "growth_form": "tree",
   "region": "saraswati-godavari-deltas",
   "biomes": [
     "sea",

--- a/database/flora/flora_jungle_crested_bamboo.json
+++ b/database/flora/flora_jungle_crested_bamboo.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Jungle-Crested Bamboo",
   "scientific": "Bambusa sylvanica",
+  "growth_form": "grass",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "forest"

--- a/database/flora/flora_lapis_lazuli_reef_builder.json
+++ b/database/flora/flora_lapis_lazuli_reef_builder.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Lapis-Lazuli Reef-Builder",
   "scientific": "Tethysolithus lapis",
+  "growth_form": "coral",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "sea"

--- a/database/flora/flora_lava_glass_fern.json
+++ b/database/flora/flora_lava_glass_fern.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Lava-Glass Fern",
   "scientific": "Pteris vulcanica",
+  "growth_form": "fern",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_lesser_whisper_fig.json
+++ b/database/flora/flora_lesser_whisper_fig.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Lesser Whisper-Fig",
   "scientific": "Ficus murmurans",
+  "growth_form": "shrub",
   "region": "narmada-vindhya",
   "biomes": [
     "hills"

--- a/database/flora/flora_levitation_gourd_sky_balloon.json
+++ b/database/flora/flora_levitation_gourd_sky_balloon.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Levitation Gourd / Sky-Balloon",
   "scientific": "Cucurbita levitata",
+  "growth_form": "vine",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island",

--- a/database/flora/flora_lodestone_moss.json
+++ b/database/flora/flora_lodestone_moss.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Lodestone Moss",
   "scientific": "Bryum magneticum",
+  "growth_form": "moss",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_lotus_root_taro.json
+++ b/database/flora/flora_lotus_root_taro.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Lotus-Root Taro",
   "scientific": "Colocasia nelumbo-affinis",
+  "growth_form": "root",
   "habitats": [
     "region_saraswati_delta"
   ],

--- a/database/flora/flora_mahua.json
+++ b/database/flora/flora_mahua.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Mahua",
   "scientific": "Madhuca longifolia",
+  "growth_form": "tree",
   "habitats": [
     "region_narmada_plateau",
     "region_aravali"

--- a/database/flora/flora_mappa_mundi_banyan.json
+++ b/database/flora/flora_mappa_mundi_banyan.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Mappa Mundi Banyan",
   "scientific": "Ficus mappa",
+  "growth_form": "tree",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "forest",

--- a/database/flora/flora_moon_reflecting_mint.json
+++ b/database/flora/flora_moon_reflecting_mint.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Moon-Reflecting Mint",
   "scientific": "Glassa luna",
+  "growth_form": "shrub",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_moonseed_vine.json
+++ b/database/flora/flora_moonseed_vine.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Moonseed Vine",
   "scientific": "Menispermum tethys",
+  "growth_form": "vine",
   "habitats": [
     "region_aravali",
     "region_narmada_plateau"

--- a/database/flora/flora_myrrh_thorn.json
+++ b/database/flora/flora_myrrh_thorn.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Myrrh-Thorn",
   "scientific": "Commiphora spinosa",
+  "growth_form": "shrub",
   "habitats": [
     "region_gedrosian_desert"
   ],

--- a/database/flora/flora_naraka_pitcher_plant.json
+++ b/database/flora/flora_naraka_pitcher_plant.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Naraka Pitcher-Plant",
   "scientific": "Nepenthes asurica",
+  "growth_form": "pitcher",
   "region": "asura-conjurations",
   "biomes": [
     "underworld"

--- a/database/flora/flora_neem.json
+++ b/database/flora/flora_neem.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Neem",
   "scientific": "Azadirachta indica",
+  "growth_form": "tree",
   "habitats": [
     "region_saraswati_delta",
     "region_narmada_plateau"

--- a/database/flora/flora_oasis_date_palm.json
+++ b/database/flora/flora_oasis_date_palm.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Oasis Date Palm",
   "scientific": "Phoenix dactylifera oasis",
+  "growth_form": "palm",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_obsidian_rose.json
+++ b/database/flora/flora_obsidian_rose.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Obsidian Rose",
   "scientific": "Rosa obsidiana",
+  "growth_form": "flower",
   "region": "asura-conjurations",
   "biomes": [
     "settlement"

--- a/database/flora/flora_pepper_vine.json
+++ b/database/flora/flora_pepper_vine.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Pepper Vine",
   "scientific": "Piper tethys",
+  "growth_form": "vine",
   "habitats": [
     "region_narmada_plateau",
     "canopy"

--- a/database/flora/flora_plunging_fire_siege_tree.json
+++ b/database/flora/flora_plunging_fire_siege_tree.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Plunging-Fire Siege Tree",
   "scientific": "Rakshasa-Vriksha",
+  "growth_form": "tree",
   "region": "asura-conjurations",
   "biomes": [
     "forest"

--- a/database/flora/flora_poison_barb_indigo.json
+++ b/database/flora/flora_poison_barb_indigo.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Poison-barb Indigo",
   "scientific": "Indigofera spicata",
+  "growth_form": "shrub",
   "region": "saraswati-godavari-deltas",
   "biomes": [
     "wetland",

--- a/database/flora/flora_poison_oleander.json
+++ b/database/flora/flora_poison_oleander.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Poison Oleander",
   "scientific": "Nerium oleander",
+  "growth_form": "flower",
   "habitats": [
     "region_aravali",
     "region_gedrosian_desert"

--- a/database/flora/flora_prana_lotus.json
+++ b/database/flora/flora_prana_lotus.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Prana-Lotus",
   "scientific": "Nelumbo prana",
+  "growth_form": "flower",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_red_blood_coral.json
+++ b/database/flora/flora_red_blood_coral.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Red Blood-Coral",
   "scientific": "Tethysolithus rubra",
+  "growth_form": "coral",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "sea"

--- a/database/flora/flora_red_delta_rice.json
+++ b/database/flora/flora_red_delta_rice.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Red Delta Rice",
   "scientific": "Oryza rubra-delta",
+  "growth_form": "grass",
   "habitats": [
     "region_saraswati_delta"
   ],

--- a/database/flora/flora_root_anchored_artillery_tree.json
+++ b/database/flora/flora_root_anchored_artillery_tree.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Root-Anchored Artillery Tree",
   "scientific": "Rakshasa-Vriksha ferrea",
+  "growth_form": "tree",
   "region": "asura-conjurations",
   "biomes": [
     "forest",

--- a/database/flora/flora_sacred_tulsi.json
+++ b/database/flora/flora_sacred_tulsi.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Sacred Tulsi",
   "scientific": "Ocimum sanctum",
+  "growth_form": "shrub",
   "habitats": [
     "settlement_lothal",
     "region_narmada_plateau"

--- a/database/flora/flora_saltreed.json
+++ b/database/flora/flora_saltreed.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Saltreed",
   "scientific": "Phragmites salina",
+  "growth_form": "grass",
   "habitats": [
     "region_saraswati_delta",
     "coastal"

--- a/database/flora/flora_sand_dune_gourd.json
+++ b/database/flora/flora_sand_dune_gourd.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Sand-Dune Gourd",
   "scientific": "Citrullus arenarius",
+  "growth_form": "vine",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_sandalwood.json
+++ b/database/flora/flora_sandalwood.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Sandalwood",
   "scientific": "Santalum jambhudweepa",
+  "growth_form": "tree",
   "habitats": [
     "region_narmada_plateau",
     "region_aravali"

--- a/database/flora/flora_saraswati_reed.json
+++ b/database/flora/flora_saraswati_reed.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Saraswati Reed",
   "scientific": "Calamus sarasvaticus",
+  "growth_form": "grass",
   "region": "saraswati-godavari-deltas",
   "biomes": [
     "wetland"

--- a/database/flora/flora_shattered_sea_kelp.json
+++ b/database/flora/flora_shattered_sea_kelp.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Shattered Sea Kelp",
   "scientific": "Macrocystis tethyan",
+  "growth_form": "seaweed",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "sea"

--- a/database/flora/flora_shattered_seaweed_silk.json
+++ b/database/flora/flora_shattered_seaweed_silk.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Shattered Seaweed-Silk",
   "scientific": "Zostera marina",
+  "growth_form": "grass",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "sea"

--- a/database/flora/flora_shilajit_creeper.json
+++ b/database/flora/flora_shilajit_creeper.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Shilajit Creeper",
   "scientific": "Cissus shilajita",
+  "growth_form": "vine",
   "habitats": [
     "region_narmada_plateau"
   ],

--- a/database/flora/flora_silver_leaved_oracle_fig.json
+++ b/database/flora/flora_silver_leaved_oracle_fig.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Silver-Leaved Oracle Fig",
   "scientific": "Ficus bhutakana",
+  "growth_form": "tree",
   "habitats": [
     "region_narmada_plateau"
   ],

--- a/database/flora/flora_snow_looming_moss.json
+++ b/database/flora/flora_snow_looming_moss.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Snow-Looming Moss",
   "scientific": "Bryum glaciale",
+  "growth_form": "moss",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_soot_grass.json
+++ b/database/flora/flora_soot_grass.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Soot-Grass",
   "scientific": "Agrostis cinerea",
+  "growth_form": "grass",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_spiny_acacia.json
+++ b/database/flora/flora_spiny_acacia.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Spiny Acacia",
   "scientific": "Acacia spinosa",
+  "growth_form": "tree",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert"

--- a/database/flora/flora_static_charged_bramble.json
+++ b/database/flora/flora_static_charged_bramble.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Static-Charged Bramble",
   "scientific": "Rubus electricus",
+  "growth_form": "shrub",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_sun_catcher_herb.json
+++ b/database/flora/flora_sun_catcher_herb.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Sun-Catcher Herb",
   "scientific": "Glassa solis",
+  "growth_form": "shrub",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_sweet_indigo.json
+++ b/database/flora/flora_sweet_indigo.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Sweet Indigo",
   "scientific": "Indigofera dulcis",
+  "growth_form": "vine",
   "habitats": [
     "region_saraswati_delta"
   ],

--- a/database/flora/flora_sweet_nectar_mahua.json
+++ b/database/flora/flora_sweet_nectar_mahua.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Sweet-Nectar Mahua",
   "scientific": "Madhuca narmadensis",
+  "growth_form": "tree",
   "region": "narmada-vindhya",
   "biomes": [
     "forest"

--- a/database/flora/flora_tamarind.json
+++ b/database/flora/flora_tamarind.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Tamarind",
   "scientific": "Tamarindus indica",
+  "growth_form": "tree",
   "habitats": [
     "region_narmada_plateau",
     "region_aravali"

--- a/database/flora/flora_tawny_sagebrush.json
+++ b/database/flora/flora_tawny_sagebrush.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Tawny Sagebrush",
   "scientific": "Artemisia tawny",
+  "growth_form": "shrub",
   "region": "gedrosian-taklamakan",
   "biomes": [
     "desert",

--- a/database/flora/flora_toxic_crimson_root.json
+++ b/database/flora/flora_toxic_crimson_root.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Toxic Crimson Root",
   "scientific": "Nirnroot rubra",
+  "growth_form": "root",
   "region": "tethys-sky-routes",
   "biomes": [
     "sky_island"

--- a/database/flora/flora_toxic_red_spore_moss.json
+++ b/database/flora/flora_toxic_red_spore_moss.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Toxic Red Spore-Moss",
   "scientific": "Dictyonema venenum",
+  "growth_form": "lichen",
   "region": "narmada-vindhya",
   "biomes": [
     "hills",

--- a/database/flora/flora_vindhya_pine.json
+++ b/database/flora/flora_vindhya_pine.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Vindhya Pine",
   "scientific": "Pinus vindhyensis",
+  "growth_form": "tree",
   "region": "narmada-vindhya",
   "biomes": [
     "hills",

--- a/database/flora/flora_violet_strangler_vine.json
+++ b/database/flora/flora_violet_strangler_vine.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Violet Strangler-Vine",
   "scientific": "Vitis violacea",
+  "growth_form": "vine",
   "region": "asura-conjurations",
   "biomes": [
     "forest"

--- a/database/flora/flora_volcanic_beach_creeper.json
+++ b/database/flora/flora_volcanic_beach_creeper.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Volcanic Beach Creeper",
   "scientific": "Ipomoea vulcanica",
+  "growth_form": "vine",
   "region": "shattered-sea-mappa-mundi",
   "biomes": [
     "forest"

--- a/database/flora/flora_volcanic_sulfur_flower.json
+++ b/database/flora/flora_volcanic_sulfur_flower.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Volcanic Sulfur-Flower",
   "scientific": "Sulfuraria lutea",
+  "growth_form": "flower",
   "region": "ganges-lava-sea",
   "biomes": [
     "lava_field",

--- a/database/flora/flora_weeping_charcoal_tree.json
+++ b/database/flora/flora_weeping_charcoal_tree.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Weeping Charcoal Tree",
   "scientific": "Ficus cinereus",
+  "growth_form": "tree",
   "region": "ganges-lava-sea",
   "biomes": [
     "forest"

--- a/database/flora/flora_whisper_fig.json
+++ b/database/flora/flora_whisper_fig.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Whisper-Fig",
   "scientific": "Ficus susurrans",
+  "growth_form": "tree",
   "habitats": [
     "region_saraswati_delta",
     "canopy"

--- a/database/flora/flora_whispering_blood_orchid.json
+++ b/database/flora/flora_whispering_blood_orchid.json
@@ -3,6 +3,7 @@
   "type": "flora",
   "name": "Whispering Blood-Orchid",
   "scientific": "Orchis asurica",
+  "growth_form": "flower",
   "region": "asura-conjurations",
   "biomes": [
     "forest"

--- a/database/growth_forms.json
+++ b/database/growth_forms.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0",
+  "description": "What shape a plant takes, declared once here so that 90 flora do not each repeat it. The companion to clades.json: that file says what an animal is, this one says what a plant is. Written for the same reason — the game had been deriving it by matching keywords against names, which is how `Saltreed` came to be a tree, its own letters containing the word.",
+  "note": "Growth form is morphology, not ancestry, and that is deliberate. `clade` groups animals by descent because a naturalist tells a crocodile from a gecko on sight and the difference is a real branch. A plant is met as a shape — a canopy, a stem, a mat on a rock — and two plants of one genus can genuinely take different shapes when one has been bred and the other has not. So a shared genus does not force a shared form here, where it does force a shared clade there.",
+  "forms": {
+    "tree": { "label": "Tree", "note": "A woody trunk holding a canopy. Includes the mangroves, whose stilt roots are still a tree." },
+    "palm": { "label": "Palm", "note": "Pulled out of `tree` because the silhouette is unmistakable and more useful than the botany." },
+    "shrub": { "label": "Shrub", "note": "Woody, branching from low down, no single trunk. The herbs live here too — tulsi, mint, sagebrush — because at the size a mark is drawn, a herb is a small bush." },
+    "vine": { "label": "Vine", "note": "Climbs or trails rather than standing. What holds it up is somebody else." },
+    "flower": { "label": "Flower", "note": "Named and known for the bloom. A rose and an oleander are woody shrubs botanically and are filed here anyway, because nobody meets a rose and thinks *bush*." },
+    "grass": { "label": "Grass", "note": "Blades from a base, including the reeds, the grains and the bamboos. The seagrasses are here as well: *Zostera* is a flowering plant that went back to the sea, not an alga." },
+    "root": { "label": "Root", "note": "The plant is the part underground — taro, turmeric, the spice-roots. What shows above it is incidental." },
+    "fern": { "label": "Fern", "note": "Fronds, no flowers." },
+    "moss": { "label": "Moss", "note": "Low cushions and mats. True bryophytes; see `lichen` for the things that only look like them." },
+    "lichen": { "label": "Lichen", "note": "Not a plant and not one organism: a fungus farming an alga. Canon has three — *Dictyonema* twice and a *Lichen* — and filing them under `moss` would repeat the mistake the whole exercise is about. They grow like moss and are nothing like it." },
+    "cactus": { "label": "Cactus", "note": "Succulent, ribbed, spined." },
+    "seaweed": { "label": "Seaweed", "note": "Marine algae. *Macrocystis* and its kind — genuinely algae, unlike the seagrasses under `grass`." },
+    "coral": {
+      "label": "Coral",
+      "note": "**An animal.** Canon files its two *Tethysolithus* reef-builders with the flora, and they are cnidarians — closer to the Sky-Faring Jellyfish than to anything else in this file. The form exists so that the database stops implying they are plants while somebody decides whether they should move to `fauna` and take a `clade` instead. That is a canon question, not a vocabulary one."
+    },
+    "pitcher": { "label": "Pitcher plant", "note": "Carnivorous. A plant with a diet is worth its own mark." }
+  }
+}

--- a/database/schemas/flora.schema.json
+++ b/database/schemas/flora.schema.json
@@ -5,7 +5,8 @@
   "required": [
     "id",
     "type",
-    "name"
+    "name",
+    "growth_form"
   ],
   "properties": {
     "id": {
@@ -23,6 +24,26 @@
         "string",
         "null"
       ]
+    },
+    "growth_form": {
+      "type": "string",
+      "enum": [
+        "tree",
+        "palm",
+        "shrub",
+        "vine",
+        "flower",
+        "grass",
+        "root",
+        "fern",
+        "moss",
+        "lichen",
+        "cactus",
+        "seaweed",
+        "coral",
+        "pitcher"
+      ],
+      "description": "What shape the plant takes, from database/growth_forms.json. The companion to `clade` on fauna, and required for the same reason: a species that does not say what it is sends the game back to guessing from its name, which is how `Saltreed` became a tree."
     },
     "taxonomy": {
       "type": "object"

--- a/docs/canon-integrity-plan.md
+++ b/docs/canon-integrity-plan.md
@@ -11,7 +11,8 @@ fauna with no scientific name. This is what it would take for it to stop doing t
 Everything below is measured against the repository as it stands on **2026-08-24**: 495 entities,
 `index.json` v1.9.0, lint reporting success.
 
-**All five phases are done.** This plan is closed; what follows is the record. Lint validates all 494 entities against 15 strict schemas, fails if `jsonschema` is missing,
+**All five phases are done, including the flora half of Phase 03 that this plan carried as open
+for a while.** Closed; what follows is the record. Lint validates all 494 entities against 15 strict schemas, fails if `jsonschema` is missing,
 enforces four cross-file invariants that JSON Schema cannot express, and
 `database/VALIDATION.md` describes what actually runs.
 
@@ -269,6 +270,7 @@ and the data it would have condemned is fixed.
 | Schemas enforced in CI | 15, covering all **494** entities |
 | Cross-file invariants | binomial, name and `source_index` uniqueness; binomial required |
 | Fauna stating their clade | **256 of 256** |
+| Flora stating their growth form | **90 of 90** |
 | Duplicate species | **0** — three pairs merged |
 | Fauna with no binomial | **0** — was eight |
 

--- a/utils/lint_story.py
+++ b/utils/lint_story.py
@@ -15,7 +15,7 @@ So it now does three things, and treats all of them as errors:
   schema        every entity validates against its type's schema
   index         index.json and the files on disk agree, in both directions
   references    every id-shaped value resolves to something that exists
-  clades        a subclade is one of *that* clade's sub-groups
+  clades        a subclade is one of *that* clade's sub-groups, and a growth form exists
   invariants    binomials, names and source_index are unique; every species has a binomial
 
 The last two are here rather than in a schema because JSON Schema validates one document at a
@@ -228,6 +228,19 @@ def main() -> int:
                     errors.append(
                         f"{path.name}: '{sub}' is not a subclade of '{clade}' (allowed: {names})"
                     )
+
+    # --- growth forms ---------------------------------------------------------------
+    #
+    # The plant half of the clade check. The schema pins the enum; this pins the *file* -- a form
+    # can be added to growth_forms.json and forgotten in the schema, or the reverse, and then the
+    # two disagree silently about what a plant is allowed to be.
+    forms_path = DB / "growth_forms.json"
+    if forms_path.exists():
+        forms = set(load(forms_path)["forms"])
+        for eid, (path, payload) in entities.items():
+            form = payload.get("growth_form")
+            if form and form not in forms:
+                errors.append(f"{path.name}: '{form}' is not a growth form in growth_forms.json")
 
     # --- invariants across sibling files -------------------------------------------
     #


### PR DESCRIPTION
The flora half of Phase 03, and the last thing this plan was carrying as open. 90 of 90 flora state a growth form, required, from the fourteen in the new database/growth_forms.json -- the companion to clades.json, and written for the same reason: the game had been deriving it from names, and that is how `Saltreed` became a tree, its own letters containing the word.

Growth form is morphology where clade is descent, and the file says so, because the difference changes a rule. A shared genus forces a shared clade -- that is the Gorgonops fix -- but it does not force a shared form: canon calls Sweet Indigo a vine and its two wild Indigofera relatives shrubs, and a bred cultivar taking a different shape is not a contradiction.

Two forms exist that the game's vocabulary does not have, and both are there to stop the database asserting something false.

`lichen`, because *Dictyonema* is a fungus farming an alga and canon has three of them. Filing those under `moss` would repeat exactly the mistake this work is about.

`coral`, because canon's two *Tethysolithus* reef-builders are cnidarians -- animals -- sitting in database/flora/. The form stops the database implying they are plants. Whether they should move to fauna and take a `clade` instead is a canon decision nobody has made, and VALIDATION.md now records it as an open question rather than leaving it implied.

Cross-checked against the game's derived classifier: **77 of 90 agree, and all thirteen disagreements are the classifier being wrong.** `gourd` sits in its cactus keywords, so two trailing vines are cacti. `lichen` sits in moss. `coral` and `kelp` sit in seaweed, which catches the actual corals and both *Zostera* seagrasses -- marine flowering plants, not algae. The rest are cases where a genus or canon's own prose should have won over a word in the common name.

I have not patched those thirteen. The classifier is the thing the clade and growth-form fields exist to delete, and rewriting eight keyword rules in a file scheduled for removal is work thrown away twice. They are the measured argument for the adapter instead.

Both fields now reach the game: the exporter passes whole entities, so species.json carries `clade` and `growth_form` without a line of change.